### PR TITLE
Add Token6 type

### DIFF
--- a/contracts/mocks/MockToken6.sol
+++ b/contracts/mocks/MockToken6.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "../types/Token6.sol";
+
+contract MockToken6 {
+    function approve(Token6 self, address grantee) external {
+        Token6Lib.approve(self, grantee);
+    }
+
+    function approve(Token6 self, address grantee, UFixed18 amount) external {
+        Token6Lib.approve(self, grantee, amount);
+    }
+
+    function approve(Token6 self, address grantee, UFixed18 amount, bool roundUp) external {
+        Token6Lib.approve(self, grantee, amount, roundUp);
+    }
+
+    function push(Token6 self, address recipient) external {
+        Token6Lib.push(self, recipient);
+    }
+
+    function push(Token6 self, address recipient, UFixed18 amount) external {
+        Token6Lib.push(self, recipient, amount);
+    }
+
+    function push(Token6 self, address recipient, UFixed18 amount, bool roundUp) external {
+        Token6Lib.push(self, recipient, amount, roundUp);
+    }
+
+    function pull(Token6 self, address benefactor, UFixed18 amount) external {
+        Token6Lib.pull(self, benefactor, amount);
+    }
+
+    function pull(Token6 self, address benefactor, UFixed18 amount, bool roundUp) external {
+        Token6Lib.pull(self, benefactor, amount, roundUp);
+    }
+
+    function pullTo(Token6 self, address benefactor, address recipient, UFixed18 amount) external {
+        Token6Lib.pullTo(self, benefactor, recipient, amount);
+    }
+
+    function pullTo(Token6 self, address benefactor, address recipient, UFixed18 amount, bool roundUp) external {
+        Token6Lib.pullTo(self, benefactor, recipient, amount, roundUp);
+    }
+
+    function name(Token6 self) external view returns (string memory) {
+        return Token6Lib.name(self);
+    }
+
+    function symbol(Token6 self) external view returns (string memory) {
+        return Token6Lib.symbol(self);
+    }
+
+    function decimals(Token6 self) external pure returns (uint256) {
+        return Token6Lib.decimals(self);
+    }
+
+    function balanceOf(Token6 self) external view returns (UFixed18) {
+        return Token6Lib.balanceOf(self);
+    }
+
+    function balanceOf(Token6 self, address account) external view returns (UFixed18) {
+        return Token6Lib.balanceOf(self, account);
+    }
+}

--- a/contracts/types/Token6.sol
+++ b/contracts/types/Token6.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+import "./UFixed18.sol";
+
+/// @dev Token6
+type Token6 is address;
+
+/**
+ * @title Token6Lib
+ * @notice Library to manage 6-decimal ERC20s that is compliant with the fixed-decimal types.
+ * @dev Automatically converts from Base-6 token amounts to Base-18 UFixed18 amounts, with optional rounding
+ */
+library Token6Lib {
+    using UFixed18Lib for UFixed18;
+    using SafeERC20 for IERC20;
+
+    uint256 private constant DECIMALS = 6;
+    uint256 private constant OFFSET = 1e12;
+
+    /**
+     * @notice Approves `grantee` to spend infinite tokens from the caller
+     * @param self Token to transfer
+     * @param grantee Address to allow spending
+     */
+    function approve(Token6 self, address grantee) internal {
+        IERC20(Token6.unwrap(self)).safeApprove(grantee, type(uint256).max);
+    }
+
+    /**
+     * @notice Approves `grantee` to spend `amount` tokens from the caller
+     * @param self Token to transfer
+     * @param grantee Address to allow spending
+     * @param amount Amount of tokens to approve to spend
+     */
+    function approve(Token6 self, address grantee, UFixed18 amount) internal {
+        IERC20(Token6.unwrap(self)).safeApprove(grantee, toTokenAmount(amount, false));
+    }
+
+    /**
+     * @notice Approves `grantee` to spend `amount` tokens from the caller
+     * @param self Token to transfer
+     * @param grantee Address to allow spending
+     * @param amount Amount of tokens to approve to spend
+     * @param roundUp Whether to round decimal token amount up to the next unit
+     */
+    function approve(Token6 self, address grantee, UFixed18 amount, bool roundUp) internal {
+        IERC20(Token6.unwrap(self)).safeApprove(grantee, toTokenAmount(amount, roundUp));
+    }
+
+    /**
+     * @notice Transfers all held tokens from the caller to the `recipient`
+     * @param self Token to transfer
+     * @param recipient Address to receive the tokens
+     */
+    function push(Token6 self, address recipient) internal {
+        push(self, recipient, balanceOf(self, address(this)));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the caller to the `recipient`
+     * @param self Token to transfer
+     * @param recipient Address to transfer tokens to
+     * @param amount Amount of tokens to transfer
+     */
+    function push(Token6 self, address recipient, UFixed18 amount) internal {
+        IERC20(Token6.unwrap(self)).safeTransfer(recipient, toTokenAmount(amount, false));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the caller to the `recipient`
+     * @param self Token to transfer
+     * @param recipient Address to transfer tokens to
+     * @param amount Amount of tokens to transfer
+     * @param roundUp Whether to round decimal token amount up to the next unit
+     */
+    function push(Token6 self, address recipient, UFixed18 amount, bool roundUp) internal {
+        IERC20(Token6.unwrap(self)).safeTransfer(recipient, toTokenAmount(amount, roundUp));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the `benefactor` to the caller
+     * @dev Reverts if trying to pull Ether
+     * @param self Token to transfer
+     * @param benefactor Address to transfer tokens from
+     * @param amount Amount of tokens to transfer
+     */
+    function pull(Token6 self, address benefactor, UFixed18 amount) internal {
+        IERC20(Token6.unwrap(self)).safeTransferFrom(benefactor, address(this), toTokenAmount(amount, false));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the `benefactor` to the caller
+     * @dev Reverts if trying to pull Ether
+     * @param self Token to transfer
+     * @param benefactor Address to transfer tokens from
+     * @param amount Amount of tokens to transfer
+     * @param roundUp Whether to round decimal token amount up to the next unit
+     */
+    function pull(Token6 self, address benefactor, UFixed18 amount, bool roundUp) internal {
+        IERC20(Token6.unwrap(self)).safeTransferFrom(benefactor, address(this), toTokenAmount(amount, roundUp));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the `benefactor` to `recipient`
+     * @dev Reverts if trying to pull Ether
+     * @param self Token to transfer
+     * @param benefactor Address to transfer tokens from
+     * @param recipient Address to transfer tokens to
+     * @param amount Amount of tokens to transfer
+     */
+    function pullTo(Token6 self, address benefactor, address recipient, UFixed18 amount) internal {
+        IERC20(Token6.unwrap(self)).safeTransferFrom(benefactor, recipient, toTokenAmount(amount, false));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the `benefactor` to `recipient`
+     * @dev Reverts if trying to pull Ether
+     * @param self Token to transfer
+     * @param benefactor Address to transfer tokens from
+     * @param recipient Address to transfer tokens to
+     * @param amount Amount of tokens to transfer
+     * @param roundUp Whether to round decimal token amount up to the next unit
+     */
+    function pullTo(Token6 self, address benefactor, address recipient, UFixed18 amount, bool roundUp) internal {
+        IERC20(Token6.unwrap(self)).safeTransferFrom(benefactor, recipient, toTokenAmount(amount, roundUp));
+    }
+
+    /**
+     * @notice Returns the name of the token
+     * @param self Token to check for
+     * @return Token name
+     */
+    function name(Token6 self) internal view returns (string memory) {
+        return IERC20Metadata(Token6.unwrap(self)).name();
+    }
+
+    /**
+     * @notice Returns the symbol of the token
+     * @param self Token to check for
+     * @return Token symbol
+     */
+    function symbol(Token6 self) internal view returns (string memory) {
+        return IERC20Metadata(Token6.unwrap(self)).symbol();
+    }
+
+    /**
+     * @notice Returns the decimals of the token
+     * @param self Token to check for
+     * @return Token decimals
+     */
+    function decimals(Token6 self) internal pure returns (uint256) {
+        return DECIMALS;
+    }
+
+    /**
+     * @notice Returns the `self` token balance of the caller
+     * @param self Token to check for
+     * @return Token balance of the caller
+     */
+    function balanceOf(Token6 self) internal view returns (UFixed18) {
+        return balanceOf(self, address(this));
+    }
+
+    /**
+     * @notice Returns the `self` token balance of `account`
+     * @param self Token to check for
+     * @param account Account to check
+     * @return Token balance of the account
+     */
+    function balanceOf(Token6 self, address account) internal view returns (UFixed18) {
+        return fromTokenAmount(IERC20(Token6.unwrap(self)).balanceOf(account));
+    }
+
+    /**
+     * @notice Converts the unsigned fixed-decimal amount into the token amount according to
+     *         it's defined decimals
+     * @dev Provides the ability to "round up" the token amount which is useful in situations where
+     *      are swapping one token for another and don't want to give away "free" units due to rounding
+     *      errors in the favor of the user.
+     * @param amount Amount to convert
+     * @param roundUp Whether to round decimal token amount up to the next unit
+     * @return Normalized token amount
+     */
+    function toTokenAmount(UFixed18 amount, bool roundUp) private pure returns (uint256) {
+        return roundUp ? Math.ceilDiv(UFixed18.unwrap(amount), OFFSET) : UFixed18.unwrap(amount) / OFFSET;
+    }
+
+    /**
+     * @notice Converts the token amount into the unsigned fixed-decimal amount according to
+     *         it's defined decimals
+     * @param amount Token amount to convert
+     * @return Normalized unsigned fixed-decimal amount
+     */
+    function fromTokenAmount(uint256 amount) private pure returns (UFixed18) {
+        return UFixed18.wrap(amount * OFFSET);
+    }
+}

--- a/test/unit/types/Token6.test.ts
+++ b/test/unit/types/Token6.test.ts
@@ -1,0 +1,279 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { utils } from 'ethers'
+import { expect } from 'chai'
+import HRE, { waffle } from 'hardhat'
+
+import { IERC20Metadata__factory, MockToken6, MockToken6__factory } from '../../../types/generated'
+import { MockContract } from '@ethereum-waffle/mock-contract'
+
+const { ethers } = HRE
+
+describe('Token6', () => {
+  let user: SignerWithAddress
+  let recipient: SignerWithAddress
+  let token6: MockToken6
+  let erc20: MockContract
+
+  beforeEach(async () => {
+    ;[user, recipient] = await ethers.getSigners()
+    token6 = await new MockToken6__factory(user).deploy()
+    erc20 = await waffle.deployMockContract(user, IERC20Metadata__factory.abi)
+  })
+
+  describe('#approve', async () => {
+    it('approves tokens', async () => {
+      await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['approve(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100'))
+    })
+
+    it('approves tokens (round down implicit)', async () => {
+      await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['approve(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100').add(1))
+    })
+
+    it('approves tokens (round down explicit)', async () => {
+      await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['approve(address,address,uint256,bool)'](
+          erc20.address,
+          recipient.address,
+          utils.parseEther('100').add(1),
+          false,
+        )
+    })
+
+    it('approves tokens (round up)', async () => {
+      await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, 100_000_001).returns(true)
+
+      await token6
+        .connect(user)
+        ['approve(address,address,uint256,bool)'](
+          erc20.address,
+          recipient.address,
+          utils.parseEther('100').add(1),
+          true,
+        )
+    })
+
+    it('approves tokens (round up when no decimal)', async () => {
+      await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['approve(address,address,uint256,bool)'](erc20.address, recipient.address, utils.parseEther('100'), true)
+    })
+
+    it('approves tokens all', async () => {
+      await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, ethers.constants.MaxUint256).returns(true)
+
+      await token6.connect(user)['approve(address,address)'](erc20.address, recipient.address)
+    })
+  })
+
+  describe('#push', async () => {
+    it('transfers tokens', async () => {
+      await erc20.mock.transfer.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['push(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100'))
+    })
+
+    it('transfers tokens (round down implicit)', async () => {
+      await erc20.mock.transfer.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['push(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100').add(1))
+    })
+
+    it('transfers tokens (round down explicit)', async () => {
+      await erc20.mock.transfer.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['push(address,address,uint256,bool)'](erc20.address, recipient.address, utils.parseEther('100').add(1), false)
+    })
+
+    it('transfers tokens (round up)', async () => {
+      await erc20.mock.transfer.withArgs(recipient.address, 100_000_001).returns(true)
+
+      await token6
+        .connect(user)
+        ['push(address,address,uint256,bool)'](erc20.address, recipient.address, utils.parseEther('100').add(1), true)
+    })
+
+    it('transfers tokens (round up when no decimal)', async () => {
+      await erc20.mock.transfer.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['push(address,address,uint256,bool)'](erc20.address, recipient.address, utils.parseEther('100'), true)
+    })
+
+    it('transfers tokens all', async () => {
+      await erc20.mock.balanceOf.withArgs(token6.address).returns(100_000_000)
+      await erc20.mock.transfer.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6.connect(user)['push(address,address)'](erc20.address, recipient.address)
+    })
+  })
+
+  describe('#pull', async () => {
+    it('transfers tokens', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, token6.address, 100_000_000).returns(true)
+
+      await token6.connect(user)['pull(address,address,uint256)'](erc20.address, user.address, utils.parseEther('100'))
+    })
+
+    it('transfers tokens (round down implicit)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, token6.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pull(address,address,uint256)'](erc20.address, user.address, utils.parseEther('100').add(1))
+    })
+
+    it('transfers tokens (round down explicit)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, token6.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pull(address,address,uint256,bool)'](erc20.address, user.address, utils.parseEther('100').add(1), false)
+    })
+
+    it('transfers tokens (round up)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, token6.address, 100_000_001).returns(true)
+
+      await token6
+        .connect(user)
+        ['pull(address,address,uint256,bool)'](erc20.address, user.address, utils.parseEther('100').add(1), true)
+    })
+
+    it('transfers tokens (round up when no decimal)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, token6.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pull(address,address,uint256,bool)'](erc20.address, user.address, utils.parseEther('100'), true)
+    })
+  })
+
+  describe('#pullTo', async () => {
+    it('transfers tokens', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pullTo(address,address,address,uint256)'](
+          erc20.address,
+          user.address,
+          recipient.address,
+          utils.parseEther('100'),
+        )
+    })
+
+    it('transfers tokens (round down implicit)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pullTo(address,address,address,uint256)'](
+          erc20.address,
+          user.address,
+          recipient.address,
+          utils.parseEther('100').add(1),
+        )
+    })
+
+    it('transfers tokens (round down explicit)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pullTo(address,address,address,uint256,bool)'](
+          erc20.address,
+          user.address,
+          recipient.address,
+          utils.parseEther('100').add(1),
+          false,
+        )
+    })
+
+    it('transfers tokens (round up)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, recipient.address, 100_000_001).returns(true)
+
+      await token6
+        .connect(user)
+        ['pullTo(address,address,address,uint256,bool)'](
+          erc20.address,
+          user.address,
+          recipient.address,
+          utils.parseEther('100').add(1),
+          true,
+        )
+    })
+
+    it('transfers tokens (round up when no decimal)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pullTo(address,address,address,uint256,bool)'](
+          erc20.address,
+          user.address,
+          recipient.address,
+          utils.parseEther('100'),
+          true,
+        )
+    })
+  })
+
+  describe('#name', async () => {
+    it('returns name', async () => {
+      await erc20.mock.name.withArgs().returns('Token Name')
+      expect(await token6.connect(user).name(erc20.address)).to.equal('Token Name')
+    })
+  })
+
+  describe('#symbol', async () => {
+    it('returns symbol', async () => {
+      await erc20.mock.symbol.withArgs().returns('TN')
+      expect(await token6.connect(user).symbol(erc20.address)).to.equal('TN')
+    })
+  })
+
+  describe('#decimals', async () => {
+    it('returns decimals', async () => {
+      expect(await token6.connect(user).decimals(erc20.address)).to.equal(6)
+    })
+  })
+
+  describe('#balanceOf', async () => {
+    it('returns balance', async () => {
+      await erc20.mock.balanceOf.withArgs(user.address).returns(100_000_000)
+      expect(await token6.connect(user)['balanceOf(address,address)'](erc20.address, user.address)).to.equal(
+        utils.parseEther('100'),
+      )
+    })
+
+    it('returns balance all', async () => {
+      await erc20.mock.balanceOf.withArgs(token6.address).returns(100_000_000)
+      expect(await token6.connect(user)['balanceOf(address)'](erc20.address)).to.equal(utils.parseEther('100'))
+    })
+  })
+})


### PR DESCRIPTION
Adds a static-base `Token` type for 6-decimal ERC20 tokens called: `Token6`.

This type gives significant gas savings over the `Token` alternative since its base conversion can be hard-coded.