### PR TITLE
Add Token18 type

### DIFF
--- a/contracts/mocks/MockToken18.sol
+++ b/contracts/mocks/MockToken18.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "../types/Token18.sol";
+
+contract MockToken18 {
+    function approve(Token18 self, address grantee) external {
+        Token18Lib.approve(self, grantee);
+    }
+
+    function approve(Token18 self, address grantee, UFixed18 amount) external {
+        Token18Lib.approve(self, grantee, amount);
+    }
+
+    function push(Token18 self, address recipient) external {
+        Token18Lib.push(self, recipient);
+    }
+
+    function push(Token18 self, address recipient, UFixed18 amount) external {
+        Token18Lib.push(self, recipient, amount);
+    }
+
+    function pull(Token18 self, address benefactor, UFixed18 amount) external {
+        Token18Lib.pull(self, benefactor, amount);
+    }
+
+    function pullTo(Token18 self, address benefactor, address recipient, UFixed18 amount) external {
+        Token18Lib.pullTo(self, benefactor, recipient, amount);
+    }
+
+    function name(Token18 self) external view returns (string memory) {
+        return Token18Lib.name(self);
+    }
+
+    function symbol(Token18 self) external view returns (string memory) {
+        return Token18Lib.symbol(self);
+    }
+
+    function decimals(Token18 self) external pure returns (uint256) {
+        return Token18Lib.decimals(self);
+    }
+
+    function balanceOf(Token18 self) external view returns (UFixed18) {
+        return Token18Lib.balanceOf(self);
+    }
+
+    function balanceOf(Token18 self, address account) external view returns (UFixed18) {
+        return Token18Lib.balanceOf(self, account);
+    }
+}

--- a/contracts/types/Token18.sol
+++ b/contracts/types/Token18.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "./UFixed18.sol";
+
+/// @dev Token18
+type Token18 is address;
+
+/**
+ * @title Token18Lib
+ * @notice Library to manage 18-decimal ERC20s that is compliant with the fixed-decimal types.
+ * @dev Maintains significant gas savings over other Token implementations since no conversion take place
+ */
+library Token18Lib {
+    using UFixed18Lib for UFixed18;
+    using SafeERC20 for IERC20;
+
+    uint256 private constant DECIMALS = 18;
+
+    /**
+     * @notice Approves `grantee` to spend infinite tokens from the caller
+     * @param self Token to transfer
+     * @param grantee Address to allow spending
+     */
+    function approve(Token18 self, address grantee) internal {
+        IERC20(Token18.unwrap(self)).safeApprove(grantee, type(uint256).max);
+    }
+
+    /**
+     * @notice Approves `grantee` to spend `amount` tokens from the caller
+     * @param self Token to transfer
+     * @param grantee Address to allow spending
+     * @param amount Amount of tokens to approve to spend
+     */
+    function approve(Token18 self, address grantee, UFixed18 amount) internal {
+        IERC20(Token18.unwrap(self)).safeApprove(grantee, UFixed18.unwrap(amount));
+    }
+
+    /**
+     * @notice Transfers all held tokens from the caller to the `recipient`
+     * @param self Token to transfer
+     * @param recipient Address to receive the tokens
+     */
+    function push(Token18 self, address recipient) internal {
+        push(self, recipient, balanceOf(self, address(this)));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the caller to the `recipient`
+     * @param self Token to transfer
+     * @param recipient Address to transfer tokens to
+     * @param amount Amount of tokens to transfer
+     */
+    function push(Token18 self, address recipient, UFixed18 amount) internal {
+        IERC20(Token18.unwrap(self)).safeTransfer(recipient, UFixed18.unwrap(amount));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the `benefactor` to the caller
+     * @dev Reverts if trying to pull Ether
+     * @param self Token to transfer
+     * @param benefactor Address to transfer tokens from
+     * @param amount Amount of tokens to transfer
+     */
+    function pull(Token18 self, address benefactor, UFixed18 amount) internal {
+        IERC20(Token18.unwrap(self)).safeTransferFrom(benefactor, address(this), UFixed18.unwrap(amount));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the `benefactor` to `recipient`
+     * @dev Reverts if trying to pull Ether
+     * @param self Token to transfer
+     * @param benefactor Address to transfer tokens from
+     * @param recipient Address to transfer tokens to
+     * @param amount Amount of tokens to transfer
+     */
+    function pullTo(Token18 self, address benefactor, address recipient, UFixed18 amount) internal {
+        IERC20(Token18.unwrap(self)).safeTransferFrom(benefactor, recipient, UFixed18.unwrap(amount));
+    }
+
+    /**
+     * @notice Returns the name of the token
+     * @param self Token to check for
+     * @return Token name
+     */
+    function name(Token18 self) internal view returns (string memory) {
+        return IERC20Metadata(Token18.unwrap(self)).name();
+    }
+
+    /**
+     * @notice Returns the symbol of the token
+     * @param self Token to check for
+     * @return Token symbol
+     */
+    function symbol(Token18 self) internal view returns (string memory) {
+        return IERC20Metadata(Token18.unwrap(self)).symbol();
+    }
+
+    /**
+     * @notice Returns the decimals of the token
+     * @param self Token to check for
+     * @return Token decimals
+     */
+    function decimals(Token18 self) internal pure returns (uint256) {
+        return DECIMALS;
+    }
+
+    /**
+     * @notice Returns the `self` token balance of the caller
+     * @param self Token to check for
+     * @return Token balance of the caller
+     */
+    function balanceOf(Token18 self) internal view returns (UFixed18) {
+        return balanceOf(self, address(this));
+    }
+
+    /**
+     * @notice Returns the `self` token balance of `account`
+     * @param self Token to check for
+     * @param account Account to check
+     * @return Token balance of the account
+     */
+    function balanceOf(Token18 self, address account) internal view returns (UFixed18) {
+        return UFixed18.wrap(IERC20(Token18.unwrap(self)).balanceOf(account));
+    }
+}

--- a/test/unit/types/Token18.test.ts
+++ b/test/unit/types/Token18.test.ts
@@ -1,0 +1,107 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { utils } from 'ethers'
+import { expect } from 'chai'
+import HRE, { waffle } from 'hardhat'
+
+import { IERC20Metadata__factory, MockToken18, MockToken18__factory } from '../../../types/generated'
+import { MockContract } from '@ethereum-waffle/mock-contract'
+
+const { ethers } = HRE
+
+describe('Token18', () => {
+  let user: SignerWithAddress
+  let recipient: SignerWithAddress
+  let token18: MockToken18
+  let erc20: MockContract
+
+  beforeEach(async () => {
+    ;[user, recipient] = await ethers.getSigners()
+    token18 = await new MockToken18__factory(user).deploy()
+    erc20 = await waffle.deployMockContract(user, IERC20Metadata__factory.abi)
+  })
+
+  describe('#approve', async () => {
+    it('approves tokens', async () => {
+      await erc20.mock.allowance.withArgs(token18.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, utils.parseEther('100')).returns(true)
+
+      await token18
+        .connect(user)
+        ['approve(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100'))
+    })
+
+    it('approves tokens all', async () => {
+      await erc20.mock.allowance.withArgs(token18.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, ethers.constants.MaxUint256).returns(true)
+
+      await token18.connect(user)['approve(address,address)'](erc20.address, recipient.address)
+    })
+  })
+
+  describe('#push', async () => {
+    it('transfers tokens', async () => {
+      await erc20.mock.transfer.withArgs(recipient.address, utils.parseEther('100')).returns(true)
+
+      await token18
+        .connect(user)
+        ['push(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100'))
+    })
+
+    it('transfers tokens all', async () => {
+      await erc20.mock.balanceOf.withArgs(token18.address).returns(utils.parseEther('100'))
+      await erc20.mock.transfer.withArgs(recipient.address, utils.parseEther('100')).returns(true)
+
+      await token18.connect(user)['push(address,address)'](erc20.address, recipient.address)
+    })
+  })
+
+  describe('#pull', async () => {
+    it('transfers tokens', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, token18.address, utils.parseEther('100')).returns(true)
+
+      await token18.connect(user).pull(erc20.address, user.address, utils.parseEther('100'))
+    })
+  })
+
+  describe('#pullTo', async () => {
+    it('transfers tokens', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, recipient.address, utils.parseEther('100')).returns(true)
+
+      await token18.connect(user).pullTo(erc20.address, user.address, recipient.address, utils.parseEther('100'))
+    })
+  })
+
+  describe('#name', async () => {
+    it('returns name', async () => {
+      await erc20.mock.name.withArgs().returns('Token Name')
+      expect(await token18.connect(user).name(erc20.address)).to.equal('Token Name')
+    })
+  })
+
+  describe('#symbol', async () => {
+    it('returns symbol', async () => {
+      await erc20.mock.symbol.withArgs().returns('TN')
+      expect(await token18.connect(user).symbol(erc20.address)).to.equal('TN')
+    })
+  })
+
+  describe('#decimals', async () => {
+    it('returns decimals', async () => {
+      expect(await token18.connect(user).decimals(erc20.address)).to.equal(18)
+    })
+  })
+
+  describe('#balanceOf', async () => {
+    it('returns balance', async () => {
+      await erc20.mock.balanceOf.withArgs(user.address).returns(utils.parseEther('100'))
+      expect(await token18.connect(user)['balanceOf(address,address)'](erc20.address, user.address)).to.equal(
+        utils.parseEther('100'),
+      )
+    })
+
+    it('returns balance all', async () => {
+      await erc20.mock.balanceOf.withArgs(token18.address).returns(utils.parseEther('100'))
+      expect(await token18.connect(user)['balanceOf(address)'](erc20.address)).to.equal(utils.parseEther('100'))
+    })
+  })
+})


### PR DESCRIPTION
Adds a static-base `Token` type for 18-decimal ERC20 tokens called: `Token18`.

This type gives significant gas savings over the `Token` alternative since it does not require any base conversions.