### PR TITLE
Add using global support

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"

--- a/contracts/types/Fixed18.sol
+++ b/contracts/types/Fixed18.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.13;
 
 import "./UFixed18.sol";
 
 /// @dev Fixed18 type
 type Fixed18 is int256;
+using Fixed18Lib for Fixed18 global;
 
 /**
  * @title Fixed18Lib

--- a/contracts/types/Token.sol
+++ b/contracts/types/Token.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -10,6 +10,7 @@ import "./UFixed18.sol";
 
 /// @dev Token
 type Token is address;
+using TokenLib for Token global;
 
 /**
  * @title TokenLib

--- a/contracts/types/Token18.sol
+++ b/contracts/types/Token18.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -8,6 +8,7 @@ import "./UFixed18.sol";
 
 /// @dev Token18
 type Token18 is address;
+using Token18Lib for Token18 global;
 
 /**
  * @title Token18Lib

--- a/contracts/types/Token6.sol
+++ b/contracts/types/Token6.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -9,6 +9,7 @@ import "./UFixed18.sol";
 
 /// @dev Token6
 type Token6 is address;
+using Token6Lib for Token6 global;
 
 /**
  * @title Token6Lib

--- a/contracts/types/UFixed18.sol
+++ b/contracts/types/UFixed18.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.13;
 
 import "./Fixed18.sol";
 
 /// @dev UFixed18 type
 type UFixed18 is uint256;
+using UFixed18Lib for UFixed18 global;
 
 /**
  * @title UFixed18Lib

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -85,7 +85,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.10',
+        version: '0.8.13',
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "scripts": {
     "build": "yarn compile",
     "compile": "hardhat compile",
@@ -61,7 +61,6 @@
       "prettier --write",
       "eslint --fix"
     ],
-    "*.sol": "solhint 'contracts/**/*.sol' --fix",
     "*.json": "prettier --write"
   }
 }


### PR DESCRIPTION
Adds support for new self-contained `using XLib for X global;` type definitions introduced in Solidity `0.8.13`.

Note: this breaks the linter again 😭 