### PR TITLE
[Upgrade] OZ library to v4.5.0

### DIFF
--- a/contracts/types/Fixed18.sol
+++ b/contracts/types/Fixed18.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+import "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import "./UFixed18.sol";
 
 /// @dev Fixed18 type
@@ -183,8 +184,7 @@ library Fixed18Lib {
      * @return Minimum of `a` and `b`
      */
     function min(Fixed18 a, Fixed18 b) internal pure returns (Fixed18) {
-        (int256 au, int256 bu) = (Fixed18.unwrap(a), Fixed18.unwrap(b));
-        return Fixed18.wrap(au < bu ? au : bu);
+        return Fixed18.wrap(SignedMath.min(Fixed18.unwrap(a), Fixed18.unwrap(b)));
     }
 
     /**
@@ -194,8 +194,7 @@ library Fixed18Lib {
      * @return Maximum of `a` and `b`
      */
     function max(Fixed18 a, Fixed18 b) internal pure returns (Fixed18) {
-        (int256 au, int256 bu) = (Fixed18.unwrap(a), Fixed18.unwrap(b));
-        return Fixed18.wrap(au > bu ? au : bu);
+        return Fixed18.wrap(SignedMath.max(Fixed18.unwrap(a), Fixed18.unwrap(b)));
     }
 
     /**
@@ -227,7 +226,6 @@ library Fixed18Lib {
      * @return Absolute value of the signed fixed-decimal
      */
     function abs(Fixed18 a) internal pure returns (UFixed18) {
-        if (Fixed18.unwrap(a) < 0) return UFixed18.wrap(uint256(-1 * Fixed18.unwrap(a)));
-        return UFixed18.wrap(uint256(Fixed18.unwrap(a)));
+        return UFixed18.wrap(SignedMath.abs(Fixed18.unwrap(a)));
     }
 }

--- a/contracts/types/UFixed18.sol
+++ b/contracts/types/UFixed18.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./Fixed18.sol";
 
 /// @dev UFixed18 type
@@ -170,8 +171,7 @@ library UFixed18Lib {
      * @return Minimum of `a` and `b`
      */
     function min(UFixed18 a, UFixed18 b) internal pure returns (UFixed18) {
-        (uint256 au, uint256 bu) = (UFixed18.unwrap(a), UFixed18.unwrap(b));
-        return UFixed18.wrap(au < bu ? au : bu);
+        return UFixed18.wrap(Math.min(UFixed18.unwrap(a), UFixed18.unwrap(b)));
     }
 
     /**
@@ -181,8 +181,7 @@ library UFixed18Lib {
      * @return Maximum of `a` and `b`
      */
     function max(UFixed18 a, UFixed18 b) internal pure returns (UFixed18) {
-        (uint256 au, uint256 bu) = (UFixed18.unwrap(a), UFixed18.unwrap(b));
-        return UFixed18.wrap(au > bu ? au : bu);
+        return UFixed18.wrap(Math.max(UFixed18.unwrap(a), UFixed18.unwrap(b)));
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.1",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
-    "@openzeppelin/contracts": "^4.2.0",
+    "@openzeppelin/contracts": "4.5.0",
     "@typechain/ethers-v5": "^7.0.1",
     "@typechain/hardhat": "^2.0.2",
     "@types/chai": "^4.2.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,10 +817,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.2.0":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.1.tgz#c01f791ce6c9d3989ac1a643267501dbe336b9e3"
-  integrity sha512-QjgbPPlmDK2clK1hzjw2ROfY8KA5q+PfhDUUxZFEBCZP9fi6d5FuNoh/Uq0oCTMEKPmue69vhX2jcl0N/tFKGw==
+"@openzeppelin/contracts@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
+  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
- Upgrades OZ library to v4.5.0
- Uses OZ math libraries for `UFixed18` / `Fixed18` calls to `min()`, `max()`, and `abs()` now that there is `Math.sol` / `SignedMath.sol` parity.