### PR TITLE
[Fix] Unstructured storage slot naming

### DIFF
--- a/contracts/mocks/MockUInitializable.sol
+++ b/contracts/mocks/MockUInitializable.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import "../unstructured/UInitializable.sol";
 
 abstract contract MockUInitializableBase {
-    bytes32 private constant INITIALIZED_SLOT = keccak256("equilibria.utils.UInitializable.initialized");
+    bytes32 private constant INITIALIZED_SLOT = keccak256("equilibria.root.UInitializable.initialized");
 
     event NoOp();
     event NoOpChild();

--- a/contracts/mocks/MockUReentrancyGuard.sol
+++ b/contracts/mocks/MockUReentrancyGuard.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import "../unstructured/UReentrancyGuard.sol";
 
 contract MockUReentrancyGuard is UReentrancyGuard {
-    bytes32 private constant STATUS_SLOT = keccak256("equilibria.utils.UReentrancyGuard.status");
+    bytes32 private constant STATUS_SLOT = keccak256("equilibria.root.UReentrancyGuard.status");
 
     event NoOp();
 

--- a/contracts/unstructured/UInitializable.sol
+++ b/contracts/unstructured/UInitializable.sol
@@ -17,10 +17,10 @@ abstract contract UInitializable {
     error UInitializableNotInitializingError();
 
     /// @dev Unstructured storage slot for the initialized flag
-    bytes32 private constant INITIALIZED_SLOT = keccak256("equilibria.utils.UInitializable.initialized");
+    bytes32 private constant INITIALIZED_SLOT = keccak256("equilibria.root.UInitializable.initialized");
 
     /// @dev Unstructured storage slot for the initializing flag
-    bytes32 private constant INITIALIZING_SLOT = keccak256("equilibria.utils.UInitializable.initializing");
+    bytes32 private constant INITIALIZING_SLOT = keccak256("equilibria.root.UInitializable.initializing");
 
     /// @dev Can only be called once, and cannot be called from another initializer or constructor
     modifier initializer() {

--- a/contracts/unstructured/UOwnable.sol
+++ b/contracts/unstructured/UOwnable.sol
@@ -12,10 +12,10 @@ import "./UInitializable.sol";
  */
 abstract contract UOwnable is UInitializable {
     /// @dev unstructured storage slot for the owner address
-    bytes32 private constant OWNER_SLOT = keccak256("equilibria.utils.UOwnable.owner");
+    bytes32 private constant OWNER_SLOT = keccak256("equilibria.root.UOwnable.owner");
 
     /// @dev unstructured storage slot for the pending owner address
-    bytes32 private constant PENDING_OWNER_SLOT = keccak256("equilibria.utils.UOwnable.pendingOwner");
+    bytes32 private constant PENDING_OWNER_SLOT = keccak256("equilibria.root.UOwnable.pendingOwner");
 
     event OwnerUpdated(address indexed newOwner);
     event PendingOwnerUpdated(address indexed newPendingOwner);

--- a/contracts/unstructured/UReentrancyGuard.sol
+++ b/contracts/unstructured/UReentrancyGuard.sol
@@ -43,7 +43,7 @@ abstract contract UReentrancyGuard is UInitializable {
     /**
      * @dev unstructured storage slot for the reentrancy status
      */
-    bytes32 private constant STATUS_SLOT = keccak256("equilibria.utils.UReentrancyGuard.status");
+    bytes32 private constant STATUS_SLOT = keccak256("equilibria.root.UReentrancyGuard.status");
 
     /**
      * @dev Initializes the contract setting the status to _NOT_ENTERED.


### PR DESCRIPTION
Corrects unstructured storage path from `equilibria.utils.xxx` -> `equilibra.root.xxx`.

**Note**: this is a breaking change, projects deployed with prior versions of `root` will no longer be compatible. 