### PR TITLE
Add packed Fixed types

### DIFF
--- a/contracts/mocks/MockFixed18.sol
+++ b/contracts/mocks/MockFixed18.sol
@@ -36,6 +36,10 @@ contract MockFixed18 {
         return Fixed18Lib.from(a);
     }
 
+    function pack(Fixed18 a) external pure returns (PackedFixed18) {
+        return Fixed18Lib.pack(a);
+    }
+
     function isZero(Fixed18 a) external pure returns (bool) {
         return Fixed18Lib.isZero(a);
     }

--- a/contracts/mocks/MockPackedFixed18.sol
+++ b/contracts/mocks/MockPackedFixed18.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "../number/types/PackedFixed18.sol";
+
+contract MockPackedFixed18 {
+    function MAX() external pure returns (PackedFixed18) {
+        return PackedFixed18Lib.MAX;
+    }
+
+    function MIN() external pure returns (PackedFixed18) {
+        return PackedFixed18Lib.MIN;
+    }
+
+    function unpack(PackedFixed18 a) external pure returns (Fixed18) {
+        return PackedFixed18Lib.unpack(a);
+    }
+}

--- a/contracts/mocks/MockPackedUFixed18.sol
+++ b/contracts/mocks/MockPackedUFixed18.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "../number/types/PackedUFixed18.sol";
+
+contract MockPackedUFixed18 {
+    function MAX() external pure returns (PackedUFixed18) {
+        return PackedUFixed18Lib.MAX;
+    }
+
+    function unpack(PackedUFixed18 a) external pure returns (UFixed18) {
+        return PackedUFixed18Lib.unpack(a);
+    }
+}

--- a/contracts/mocks/MockUFixed18.sol
+++ b/contracts/mocks/MockUFixed18.sol
@@ -24,6 +24,10 @@ contract MockUFixed18 {
         return UFixed18Lib.from(a);
     }
 
+    function pack(UFixed18 a) external pure returns (PackedUFixed18) {
+        return UFixed18Lib.pack(a);
+    }
+
     function isZero(UFixed18 a) external pure returns (bool) {
         return UFixed18Lib.isZero(a);
     }

--- a/contracts/number/types/Fixed18.sol
+++ b/contracts/number/types/Fixed18.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import "./UFixed18.sol";
+import "./PackedFixed18.sol";
 
 /// @dev Fixed18 type
 type Fixed18 is int256;
@@ -14,6 +15,8 @@ using Fixed18Lib for Fixed18 global;
  */
 library Fixed18Lib {
     error Fixed18OverflowError(uint256 value);
+    error Fixed18PackingOverflowError(int256 value);
+    error Fixed18PackingUnderflowError(int256 value);
 
     int256 private constant BASE = 1e18;
     Fixed18 public constant ZERO = Fixed18.wrap(0);
@@ -52,6 +55,19 @@ library Fixed18Lib {
      */
     function from(int256 a) internal pure returns (Fixed18) {
         return Fixed18.wrap(a * BASE);
+    }
+
+
+    /**
+     * @notice Creates a packed signed fixed-decimal from an signed fixed-decimal
+     * @param a signed fixed-decimal
+     * @return New packed signed fixed-decimal
+     */
+    function pack(Fixed18 a) internal pure returns (PackedFixed18) {
+        int256 value = Fixed18.unwrap(a);
+        if (value > type(int128).max) revert Fixed18PackingOverflowError(value);
+        if (value < type(int128).min) revert Fixed18PackingUnderflowError(value);
+        return PackedFixed18.wrap(int128(value));
     }
 
     /**

--- a/contracts/number/types/PackedFixed18.sol
+++ b/contracts/number/types/PackedFixed18.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "./Fixed18.sol";
+
+/// @dev PackedFixed18 type
+type PackedFixed18 is int128;
+using PackedFixed18Lib for PackedFixed18 global;
+
+/**
+ * @title PackedFixed18Lib
+ * @dev A packed version of the Fixed18 which takes up half the storage space (two PackedFixed18 can be packed
+ *      into a single slot). Only valid within the range -1.7014118e+20 <= x <= 1.7014118e+20.
+ * @notice Library for the packed signed fixed-decimal type.
+ */
+library PackedFixed18Lib {
+    PackedFixed18 public constant MAX = PackedFixed18.wrap(type(int128).max);
+    PackedFixed18 public constant MIN = PackedFixed18.wrap(type(int128).min);
+
+    /**
+     * @notice Creates a signed fixed-decimal from a sign and an unsigned fixed-decimal
+     * @param self Sign
+     * @return New signed fixed-decimal
+     */
+    function unpack(PackedFixed18 self) internal pure returns (Fixed18) {
+        return Fixed18.wrap(int256(PackedFixed18.unwrap(self)));
+    }
+}

--- a/contracts/number/types/PackedUFixed18.sol
+++ b/contracts/number/types/PackedUFixed18.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "./UFixed18.sol";
+
+/// @dev PackedUFixed18 type
+type PackedUFixed18 is uint128;
+using PackedUFixed18Lib for PackedUFixed18 global;
+
+/**
+ * @title PackedUFixed18Lib
+ * @dev A packed version of the UFixed18 which takes up half the storage space (two PackedUFixed18 can be packed
+ *      into a single slot). Only valid within the range 0 <= x <= 3.4028237e+20.
+ * @notice Library for the packed unsigned fixed-decimal type.
+ */
+library PackedUFixed18Lib {
+    PackedUFixed18 public constant MAX = PackedUFixed18.wrap(type(uint128).max);
+
+    /**
+     * @notice Creates a signed fixed-decimal from a sign and an unsigned fixed-decimal
+     * @param self Sign
+     * @return New signed fixed-decimal
+     */
+    function unpack(PackedUFixed18 self) internal pure returns (UFixed18) {
+        return UFixed18.wrap(uint256(PackedUFixed18.unwrap(self)));
+    }
+}

--- a/contracts/number/types/UFixed18.sol
+++ b/contracts/number/types/UFixed18.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./Fixed18.sol";
+import "./PackedUFixed18.sol";
 
 /// @dev UFixed18 type
 type UFixed18 is uint256;
@@ -14,6 +15,7 @@ using UFixed18Lib for UFixed18 global;
  */
 library UFixed18Lib {
     error UFixed18UnderflowError(int256 value);
+    error UFixed18PackingOverflowError(uint256 value);
 
     uint256 private constant BASE = 1e18;
     UFixed18 public constant ZERO = UFixed18.wrap(0);
@@ -38,6 +40,18 @@ library UFixed18Lib {
      */
     function from(uint256 a) internal pure returns (UFixed18) {
         return UFixed18.wrap(a * BASE);
+    }
+
+
+    /**
+     * @notice Creates a packed unsigned fixed-decimal from an unsigned fixed-decimal
+     * @param a unsigned fixed-decimal
+     * @return New packed unsigned fixed-decimal
+     */
+    function pack(UFixed18 a) internal pure returns (PackedUFixed18) {
+        uint256 value = UFixed18.unwrap(a);
+        if (value > type(uint128).max) revert UFixed18PackingOverflowError(value);
+        return PackedUFixed18.wrap(uint128(value));
     }
 
     /**

--- a/test/unit/number/Fixed18.test.ts
+++ b/test/unit/number/Fixed18.test.ts
@@ -77,6 +77,22 @@ describe('Fixed18', () => {
     })
   })
 
+  describe('#pack', async () => {
+    it('creates new', async () => {
+      expect(await fixed18.pack(utils.parseEther('10'))).to.equal(utils.parseEther('10'))
+    })
+
+    it('reverts if too large', async () => {
+      const TOO_LARGE = ethers.constants.MaxInt256
+      await expect(fixed18.pack(TOO_LARGE)).to.be.revertedWith(`Fixed18PackingOverflowError(${TOO_LARGE})`)
+    })
+
+    it('reverts if too small', async () => {
+      const TOO_SMALL = ethers.constants.MinInt256
+      await expect(fixed18.pack(TOO_SMALL)).to.be.revertedWith(`Fixed18PackingUnderflowError(${TOO_SMALL})`)
+    })
+  })
+
   describe('#isZero', async () => {
     it('returns true', async () => {
       expect(await fixed18.isZero(0)).to.equal(true)

--- a/test/unit/number/PackedFixed18.test.ts
+++ b/test/unit/number/PackedFixed18.test.ts
@@ -1,0 +1,36 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { utils } from 'ethers'
+import { expect } from 'chai'
+import HRE from 'hardhat'
+
+import { MockPackedFixed18, MockPackedFixed18__factory } from '../../../types/generated'
+
+const { ethers } = HRE
+
+describe('PackedFixed18', () => {
+  let user: SignerWithAddress
+  let packedFixed18: MockPackedFixed18
+
+  beforeEach(async () => {
+    ;[user] = await ethers.getSigners()
+    packedFixed18 = await new MockPackedFixed18__factory(user).deploy()
+  })
+
+  describe('#MAX', async () => {
+    it('returns max', async () => {
+      expect(await packedFixed18.MAX()).to.equal(ethers.BigNumber.from(2).pow(127).sub(1))
+    })
+  })
+
+  describe('#MIN', async () => {
+    it('returns min', async () => {
+      expect(await packedFixed18.MIN()).to.equal(ethers.BigNumber.from(2).pow(127).mul(-1))
+    })
+  })
+
+  describe('#unpack', async () => {
+    it('creates new', async () => {
+      expect(await packedFixed18.unpack(utils.parseEther('10'))).to.equal(utils.parseEther('10'))
+    })
+  })
+})

--- a/test/unit/number/PackedUFixed18.test.ts
+++ b/test/unit/number/PackedUFixed18.test.ts
@@ -1,0 +1,30 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { utils } from 'ethers'
+import { expect } from 'chai'
+import HRE from 'hardhat'
+
+import { MockPackedUFixed18, MockPackedUFixed18__factory } from '../../../types/generated'
+
+const { ethers } = HRE
+
+describe('PackedUFixed18', () => {
+  let user: SignerWithAddress
+  let packedUFixed18: MockPackedUFixed18
+
+  beforeEach(async () => {
+    ;[user] = await ethers.getSigners()
+    packedUFixed18 = await new MockPackedUFixed18__factory(user).deploy()
+  })
+
+  describe('#MAX', async () => {
+    it('returns max', async () => {
+      expect(await packedUFixed18.MAX()).to.equal(ethers.BigNumber.from(2).pow(128).sub(1))
+    })
+  })
+
+  describe('#unpack', async () => {
+    it('creates new', async () => {
+      expect(await packedUFixed18.unpack(utils.parseEther('10'))).to.equal(utils.parseEther('10'))
+    })
+  })
+})

--- a/test/unit/number/UFixed18.test.ts
+++ b/test/unit/number/UFixed18.test.ts
@@ -52,6 +52,17 @@ describe('UFixed18', () => {
     })
   })
 
+  describe('#pack', async () => {
+    it('creates new', async () => {
+      expect(await uFixed18.pack(utils.parseEther('10'))).to.equal(utils.parseEther('10'))
+    })
+
+    it('reverts if too large', async () => {
+      const TOO_LARGE = ethers.constants.MaxUint256
+      await expect(uFixed18.pack(TOO_LARGE)).to.be.revertedWith(`UFixed18PackingOverflowError(${TOO_LARGE})`)
+    })
+  })
+
   describe('#isZero', async () => {
     it('returns true', async () => {
       expect(await uFixed18.isZero(0)).to.equal(true)


### PR DESCRIPTION
Adds packed fixed-decimal number types that use up half of the normal storage slot - two of these numbers can be packed into a single storage slot for gas efficiency.