### PR TITLE
Add unsafeDiv to Fixed-decimal types

### DIFF
--- a/contracts/mocks/MockFixed18.sol
+++ b/contracts/mocks/MockFixed18.sol
@@ -60,6 +60,10 @@ contract MockFixed18 {
         return Fixed18Lib.div(a, b);
     }
 
+    function unsafeDiv(Fixed18 a, Fixed18 b) external pure returns (Fixed18) {
+        return Fixed18Lib.unsafeDiv(a, b);
+    }
+
     function eq(Fixed18 a, Fixed18 b) external pure returns (bool) {
         return Fixed18Lib.eq(a, b);
     }

--- a/contracts/mocks/MockUFixed18.sol
+++ b/contracts/mocks/MockUFixed18.sol
@@ -48,6 +48,10 @@ contract MockUFixed18 {
         return UFixed18Lib.div(a, b);
     }
 
+    function unsafeDiv(UFixed18 a, UFixed18 b) external pure returns (UFixed18) {
+        return UFixed18Lib.unsafeDiv(a, b);
+    }
+
     function eq(UFixed18 a, UFixed18 b) external pure returns (bool) {
         return UFixed18Lib.eq(a, b);
     }

--- a/contracts/number/types/Fixed18.sol
+++ b/contracts/number/types/Fixed18.sol
@@ -112,10 +112,27 @@ library Fixed18Lib {
      * @notice Divides signed fixed-decimal `a` by `b`
      * @param a Signed fixed-decimal to divide
      * @param b Signed fixed-decimal to divide by
-     * @return Resulting subtracted signed fixed-decimal
+     * @return Resulting divided signed fixed-decimal
      */
     function div(Fixed18 a, Fixed18 b) internal pure returns (Fixed18) {
         return Fixed18.wrap(Fixed18.unwrap(a) * BASE / Fixed18.unwrap(b));
+    }
+
+    /**
+     * @notice Divides unsigned fixed-decimal `a` by `b`
+     * @dev Does not revert on divide-by-0, instead returns `ONE` for `0/0`, `MAX` for `n/0`, and `MIN` for `-n/0`.
+     * @param a Unsigned fixed-decimal to divide
+     * @param b Unsigned fixed-decimal to divide by
+     * @return Resulting divided unsigned fixed-decimal
+     */
+    function unsafeDiv(Fixed18 a, Fixed18 b) internal pure returns (Fixed18) {
+        if (isZero(b)) {
+            if (gt(a, ZERO)) return MAX;
+            if (lt(a, ZERO)) return MIN;
+            return ONE;
+        } else {
+            return div(a, b);
+        }
     }
 
     /**

--- a/contracts/number/types/UFixed18.sol
+++ b/contracts/number/types/UFixed18.sol
@@ -96,10 +96,25 @@ library UFixed18Lib {
      * @notice Divides unsigned fixed-decimal `a` by `b`
      * @param a Unsigned fixed-decimal to divide
      * @param b Unsigned fixed-decimal to divide by
-     * @return Resulting subtracted unsigned fixed-decimal
+     * @return Resulting divided unsigned fixed-decimal
      */
     function div(UFixed18 a, UFixed18 b) internal pure returns (UFixed18) {
         return UFixed18.wrap(UFixed18.unwrap(a) * BASE / UFixed18.unwrap(b));
+    }
+
+    /**
+     * @notice Divides unsigned fixed-decimal `a` by `b`
+     * @dev Does not revert on divide-by-0, instead returns `ONE` for `0/0` and `MAX` for `n/0`.
+     * @param a Unsigned fixed-decimal to divide
+     * @param b Unsigned fixed-decimal to divide by
+     * @return Resulting divided unsigned fixed-decimal
+     */
+    function unsafeDiv(UFixed18 a, UFixed18 b) internal pure returns (UFixed18) {
+        if (isZero(b)) {
+            return isZero(a) ? ONE : MAX;
+        } else {
+            return div(a, b);
+        }
     }
 
     /**

--- a/test/unit/number/Fixed18.test.ts
+++ b/test/unit/number/Fixed18.test.ts
@@ -145,6 +145,44 @@ describe('Fixed18', () => {
     it('divs and floors', async () => {
       expect(await fixed18.div(21, utils.parseEther('10'))).to.equal(2)
     })
+
+    it('reverts', async () => {
+      await expect(fixed18.div(0, 0)).to.revertedWith('0x12')
+    })
+
+    it('reverts', async () => {
+      await expect(fixed18.div(utils.parseEther('20'), 0)).to.revertedWith('0x12')
+    })
+
+    it('reverts', async () => {
+      await expect(fixed18.div(utils.parseEther('-20'), 0)).to.revertedWith('0x12')
+    })
+  })
+
+  describe('#unsafeDiv', async () => {
+    it('divs', async () => {
+      expect(await fixed18.unsafeDiv(utils.parseEther('20'), utils.parseEther('10'))).to.equal(utils.parseEther('2'))
+    })
+
+    it('divs', async () => {
+      expect(await fixed18.unsafeDiv(utils.parseEther('-20'), utils.parseEther('-10'))).to.equal(utils.parseEther('2'))
+    })
+
+    it('divs and floors', async () => {
+      expect(await fixed18.unsafeDiv(21, utils.parseEther('10'))).to.equal(2)
+    })
+
+    it('divs (ONE)', async () => {
+      expect(await fixed18.unsafeDiv(0, 0)).to.equal(utils.parseEther('1'))
+    })
+
+    it('divs (MAX)', async () => {
+      expect(await fixed18.unsafeDiv(utils.parseEther('20'), 0)).to.equal(ethers.constants.MaxInt256)
+    })
+
+    it('divs (MIN)', async () => {
+      expect(await fixed18.unsafeDiv(utils.parseEther('-20'), 0)).to.equal(ethers.constants.MinInt256)
+    })
   })
 
   describe('#eq', async () => {

--- a/test/unit/number/UFixed18.test.ts
+++ b/test/unit/number/UFixed18.test.ts
@@ -99,6 +99,32 @@ describe('UFixed18', () => {
     it('divs and floors', async () => {
       expect(await uFixed18.div(21, utils.parseEther('10'))).to.equal(2)
     })
+
+    it('reverts', async () => {
+      await expect(uFixed18.div(0, 0)).to.revertedWith('0x12')
+    })
+
+    it('reverts', async () => {
+      await expect(uFixed18.div(utils.parseEther('20'), 0)).to.revertedWith('0x12')
+    })
+  })
+
+  describe('#unsafeDiv', async () => {
+    it('divs', async () => {
+      expect(await uFixed18.unsafeDiv(utils.parseEther('20'), utils.parseEther('10'))).to.equal(utils.parseEther('2'))
+    })
+
+    it('divs and floors', async () => {
+      expect(await uFixed18.unsafeDiv(21, utils.parseEther('10'))).to.equal(2)
+    })
+
+    it('divs (ONE)', async () => {
+      expect(await uFixed18.unsafeDiv(0, 0)).to.equal(utils.parseEther('1'))
+    })
+
+    it('divs (MAX)', async () => {
+      expect(await uFixed18.unsafeDiv(utils.parseEther('20'), 0)).to.equal(ethers.constants.MaxUint256)
+    })
   })
 
   describe('#eq', async () => {


### PR DESCRIPTION
Adds new `unsafeDiv` method to `UFixed18` and `Fixed18` types.

Instead of reverting on divide-by-0 `unsafeDiv` returns:
- `ONE` when `0 / 0`
- `MAX` when `n / 0` (for positive n)
- `MIN` when `n / 0` (for negative n)

This is useful in systems where a denominator of `0` is expected to avoid extra branch cases.