### PR TITLE
[Update] Update UInitializer pattern

### DIFF
--- a/contracts/mocks/MockUInitializable.sol
+++ b/contracts/mocks/MockUInitializable.sol
@@ -4,24 +4,24 @@ pragma solidity ^0.8.13;
 import "../control/unstructured/UInitializable.sol";
 
 contract MockUInitializable is UInitializable {
-    BoolStorage private constant _initialized = BoolStorage.wrap(keccak256("equilibria.root.UInitializable.initialized"));
+    Uint256Storage private constant _version = Uint256Storage.wrap(keccak256("equilibria.root.UInitializable.version"));
 
     event NoOp();
     event NoOpChild();
 
-    function __initialized() external view returns (bool) {
-        return _initialized.read();
+    function __version() external view returns (uint256) {
+        return _version.read();
     }
 
-    function initialize() public initializer {
+    function initialize() public initializer(1) {
         emit NoOp();
     }
 
-    function doubleInitialize() public initializer {
+    function doubleInitialize() public initializer(1) {
         initialize();
     }
 
-    function initializeWithChildren() public initializer {
+    function initializeWithChildren() public initializer(1) {
         childInitializer();
         emit NoOp();
     }
@@ -37,21 +37,9 @@ contract MockUInitializableConstructor1 is MockUInitializable {
     }
 }
 
-contract MockUInitializableConstructor2 is MockUInitializable {
-    constructor() {
-        initialize();
-    }
-}
-
 contract MockUInitializableConstructor3 is MockUInitializable {
-    constructor() initializer {
+    constructor() initializer(1) {
         childInitializer();
-    }
-}
-
-contract MockUInitializableConstructor4 is MockUInitializable {
-    constructor() {
-        initializeWithChildren();
     }
 }
 
@@ -67,14 +55,32 @@ contract MockUInitializableConstructor6 is MockUInitializableConstructor1 {
     function childInitializer6() public onlyInitializer { }
 }
 
-contract MockUInitializableConstructor7 is MockUInitializableConstructor2 {
-    constructor() MockUInitializableConstructor2() { }
-}
-
 contract MockUInitializableConstructor8 is MockUInitializableConstructor3 {
     constructor() MockUInitializableConstructor3() { }
 }
 
-contract MockUInitializableConstructor9 is MockUInitializableConstructor4 {
-    constructor() MockUInitializableConstructor4() { }
+contract MockUInitializableMulti is UInitializable {
+    Uint256Storage private constant _version = Uint256Storage.wrap(keccak256("equilibria.root.UInitializable.version"));
+
+    event NoOp(uint256 version);
+
+    function __version() external view returns (uint256) {
+        return _version.read();
+    }
+
+    function initialize1() public initializer(1) {
+        emit NoOp(1);
+    }
+
+    function initialize2() public initializer(2) {
+        emit NoOp(2);
+    }
+
+    function initialize17() public initializer(17) {
+        emit NoOp(17);
+    }
+
+    function initializeMax() public initializer(type(uint256).max) {
+        emit NoOp(type(uint256).max);
+    }
 }

--- a/contracts/mocks/MockUJumpRateUtilizationCurveProvider.sol
+++ b/contracts/mocks/MockUJumpRateUtilizationCurveProvider.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "../curve/unstructured/UJumpRateUtilizationCurveProvider.sol";
 
 contract MockUJumpRateUtilizationCurveProvider is UJumpRateUtilizationCurveProvider {
-    function __initialize(JumpRateUtilizationCurve memory initialUtilizationCurve) external initializer {
+    function __initialize(JumpRateUtilizationCurve memory initialUtilizationCurve) external initializer(1) {
         super.__UOwnable__initialize();
         super.__UJumpRateUtilizationCurveProvider__initialize(initialUtilizationCurve);
     }

--- a/contracts/mocks/MockULinearUtilizationCurveProvider.sol
+++ b/contracts/mocks/MockULinearUtilizationCurveProvider.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "../curve/unstructured/ULinearUtilizationCurveProvider.sol";
 
 contract MockULinearUtilizationCurveProvider is ULinearUtilizationCurveProvider {
-    function __initialize(LinearUtilizationCurve memory initialUtilizationCurve) external initializer {
+    function __initialize(LinearUtilizationCurve memory initialUtilizationCurve) external initializer(1) {
         super.__UOwnable__initialize();
         super.__ULinearUtilizationCurveProvider__initialize(initialUtilizationCurve);
     }

--- a/contracts/mocks/MockUOwnable.sol
+++ b/contracts/mocks/MockUOwnable.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "../control/unstructured/UOwnable.sol";
 
 contract MockUOwnable is UOwnable {
-    function __initialize() external initializer {
+    function __initialize() external initializer(1) {
         super.__UOwnable__initialize();
     }
 }

--- a/contracts/mocks/MockUReentrancyGuard.sol
+++ b/contracts/mocks/MockUReentrancyGuard.sol
@@ -8,7 +8,7 @@ contract MockUReentrancyGuard is UReentrancyGuard {
 
     event NoOp();
 
-    function __initialize() external initializer {
+    function __initialize() external initializer(1) {
         super.__UReentrancyGuard__initialize();
     }
 

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"
@@ -19,5 +19,8 @@
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/equilibria-xyz/root/issues"
+  },
+  "peerDependencies": {
+    "@openzeppelin/contracts": "4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "build": "yarn compile",
     "compile": "hardhat compile",


### PR DESCRIPTION
Updates the `UInitializer` to support versions, keeping inline with the OZ feature set [here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/utils/Initializable.sol).

### Quality of Life
- Fixes a bug where proxies could not call initializers on setup since constructor calls were explicitly blocked.
-Updates `root` to `v0.1.2` and adds OZ as a peer dependency.