### PR TITLE
[Fix] Enable Solidity v0.8.14

### DIFF
--- a/contracts/storage/UStorage.sol
+++ b/contracts/storage/UStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "../number/types/UFixed18.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -85,7 +85,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.13',
+        version: '0.8.14',
         settings: {
           optimizer: {
             enabled: false,


### PR DESCRIPTION
Updates pragma in `UStorage.sol` to allow versions above `0.8.13`.