### PR TITLE
[Update] Bump OZ

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/equilibria-xyz/root/issues"
   },
-  "peerDependencies": {
-    "@openzeppelin/contracts": "4.5.0"
+  "dependencies": {
+    "@openzeppelin/contracts": "4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "scripts": {
     "build": "yarn compile",
     "compile": "hardhat compile",
@@ -23,7 +23,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.1",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
-    "@openzeppelin/contracts": "4.5.0",
+    "@openzeppelin/contracts": "4.6.0",
     "@typechain/ethers-v5": "^7.0.1",
     "@typechain/hardhat": "^2.0.2",
     "@types/chai": "^4.2.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,10 +817,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
-  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
+"@openzeppelin/contracts@4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
+  integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
- Bumps OZ to `v4.6.0`
- Bumps root to `v0.1.5`
- Uses `dependency` instead of `peerDependency` in internal library `package.json`