### PR TITLE
Unchecked math in number types

### DIFF
--- a/contracts/number/types/Fixed18.sol
+++ b/contracts/number/types/Fixed18.sol
@@ -46,7 +46,12 @@ library Fixed18Lib {
      */
     function from(int256 s, UFixed18 m) internal pure returns (Fixed18) {
         if (s > 0) return from(m);
-        if (s < 0) return Fixed18.wrap(-1 * Fixed18.unwrap(from(m)));
+        if (s < 0) {
+            // Since from(m) multiplies m by BASE, from(m) cannot be type(int256).min
+            // which is the only value that would overflow when negated. Therefore,
+            // we can safely negate from(m) without checking for overflow.
+            unchecked { return Fixed18.wrap(-1 * Fixed18.unwrap(from(m))); }
+        }
         return ZERO;
     }
 

--- a/test/unit/number/Fixed18.test.ts
+++ b/test/unit/number/Fixed18.test.ts
@@ -52,9 +52,14 @@ describe('Fixed18', () => {
     it('creates new', async () => {
       expect(await fixed18['from(int256)'](10)).to.equal(utils.parseEther('10'))
     })
+
+    it('reverts if too large', async () => {
+      const TOO_LARGE = ethers.constants.MaxInt256.sub(10)
+      await expect(fixed18['from(int256)'](TOO_LARGE)).to.be.reverted
+    })
   })
 
-  describe('#from(Fixed18)', async () => {
+  describe('#from(int256,UFixed18)', async () => {
     it('creates positive', async () => {
       expect(await fixed18['from(int256,uint256)'](1, utils.parseEther('10'))).to.equal(utils.parseEther('10'))
     })
@@ -65,6 +70,16 @@ describe('Fixed18', () => {
 
     it('creates negative', async () => {
       expect(await fixed18['from(int256,uint256)'](-1, utils.parseEther('10'))).to.equal(utils.parseEther('-10'))
+    })
+
+    it('reverts if too large or small', async () => {
+      const TOO_LARGE = ethers.BigNumber.from(2).pow(256).sub(10)
+      await expect(fixed18['from(int256,uint256)'](1, TOO_LARGE)).to.be.revertedWith(
+        `Fixed18OverflowError(${TOO_LARGE})`,
+      )
+      await expect(fixed18['from(int256,uint256)'](-1, TOO_LARGE)).to.be.revertedWith(
+        `Fixed18OverflowError(${TOO_LARGE})`,
+      )
     })
   })
 


### PR DESCRIPTION
This reduces the gas used by `from(int256, UFixed18)` from 22440 to 22313 with `viaIR`, saving 127 gas.

One other optimization considered was wrapping division by `BASE` in `unchecked`. However, that did not save any gas.