### PR TITLE
Make Root backwards compatible

### DIFF
--- a/contracts/curve/types/JumpRateUtilizationCurve.sol
+++ b/contracts/curve/types/JumpRateUtilizationCurve.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "../CurveMath18.sol";
+import "../../number/types/UFixed18.sol";
+import "../../number/types/Fixed18.sol";
+
+/// @dev JumpRateUtilizationCurve type
+struct JumpRateUtilizationCurve {
+    Fixed18 minRate;
+    Fixed18 maxRate;
+    Fixed18 targetRate;
+    UFixed18 targetUtilization;
+}
+using JumpRateUtilizationCurveLib for JumpRateUtilizationCurve global;
+type JumpRateUtilizationCurveStorage is bytes32;
+using JumpRateUtilizationCurveStorageLib for JumpRateUtilizationCurveStorage global;
+
+/**
+ * @title JumpRateUtilizationCurveLib
+ * @notice Library for the Jump Rate utilization curve type
+ */
+library JumpRateUtilizationCurveLib {
+    /**
+     * @notice Computes the corresponding rate for a utilization ratio
+     * @param utilization The utilization ratio
+     * @return The corresponding rate
+     */
+    function compute(JumpRateUtilizationCurve memory self, UFixed18 utilization) internal pure returns (Fixed18) {
+        if (utilization.lt(self.targetUtilization)) {
+            return CurveMath18.linearInterpolation(
+                UFixed18Lib.ZERO,
+                self.minRate,
+                self.targetUtilization,
+                self.targetRate,
+                utilization
+            );
+        }
+        if (utilization.lt(UFixed18Lib.ONE)) {
+            return CurveMath18.linearInterpolation(
+                self.targetUtilization,
+                self.targetRate,
+                UFixed18Lib.ONE,
+                self.maxRate,
+                utilization
+            );
+        }
+        return self.maxRate;
+    }
+
+    function accumulate(
+        JumpRateUtilizationCurve memory self,
+        UFixed18 utilization,
+        uint256 fromTimestamp,
+        uint256 toTimestamp,
+        UFixed18 notional
+    ) internal pure returns (Fixed18) {
+        return compute(self, utilization)
+            .mul(Fixed18Lib.from(int256(toTimestamp - fromTimestamp)))
+            .mul(Fixed18Lib.from(notional))
+            .div(Fixed18Lib.from(365 days));
+    }
+}
+
+library JumpRateUtilizationCurveStorageLib {
+    function read(JumpRateUtilizationCurveStorage self) internal view returns (JumpRateUtilizationCurve memory) {
+        return _storagePointer(self);
+    }
+
+    function store(JumpRateUtilizationCurveStorage self, JumpRateUtilizationCurve memory value) internal {
+        JumpRateUtilizationCurve storage storagePointer = _storagePointer(self);
+
+        storagePointer.minRate = value.minRate;
+        storagePointer.maxRate = value.maxRate;
+        storagePointer.targetRate = value.targetRate;
+        storagePointer.targetUtilization = value.targetUtilization;
+    }
+
+    function _storagePointer(JumpRateUtilizationCurveStorage self)
+    private pure returns (JumpRateUtilizationCurve storage pointer) {
+        assembly ("memory-safe") { pointer.slot := self }
+    }
+}

--- a/contracts/mocks/MockJumpRateUtilizationCurve.sol
+++ b/contracts/mocks/MockJumpRateUtilizationCurve.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "../curve/types/JumpRateUtilizationCurve.sol";
+
+contract MockJumpRateUtilizationCurve {
+    function compute(JumpRateUtilizationCurve memory self, UFixed18 utilization) external pure returns (Fixed18) {
+        return JumpRateUtilizationCurveLib.compute(self, utilization);
+    }
+
+    function read(JumpRateUtilizationCurveStorage slot) external view returns (JumpRateUtilizationCurve memory) {
+        return slot.read();
+    }
+
+    function store(JumpRateUtilizationCurveStorage slot, JumpRateUtilizationCurve memory value) external {
+        slot.store(value);
+    }
+}

--- a/contracts/mocks/MockToken6.sol
+++ b/contracts/mocks/MockToken6.sol
@@ -20,24 +20,40 @@ contract MockToken6 {
         Token6Lib.approve(self, grantee);
     }
 
-    function approve(Token6 self, address grantee, UFixed6 amount) external {
+    function approve(Token6 self, address grantee, UFixed18 amount) external {
         Token6Lib.approve(self, grantee, amount);
+    }
+
+    function approve(Token6 self, address grantee, UFixed18 amount, bool roundUp) external {
+        Token6Lib.approve(self, grantee, amount, roundUp);
     }
 
     function push(Token6 self, address recipient) external {
         Token6Lib.push(self, recipient);
     }
 
-    function push(Token6 self, address recipient, UFixed6 amount) external {
+    function push(Token6 self, address recipient, UFixed18 amount) external {
         Token6Lib.push(self, recipient, amount);
     }
 
-    function pull(Token6 self, address benefactor, UFixed6 amount) external {
+    function push(Token6 self, address recipient, UFixed18 amount, bool roundUp) external {
+        Token6Lib.push(self, recipient, amount, roundUp);
+    }
+
+    function pull(Token6 self, address benefactor, UFixed18 amount) external {
         Token6Lib.pull(self, benefactor, amount);
     }
 
-    function pullTo(Token6 self, address benefactor, address recipient, UFixed6 amount) external {
+    function pull(Token6 self, address benefactor, UFixed18 amount, bool roundUp) external {
+        Token6Lib.pull(self, benefactor, amount, roundUp);
+    }
+
+    function pullTo(Token6 self, address benefactor, address recipient, UFixed18 amount) external {
         Token6Lib.pullTo(self, benefactor, recipient, amount);
+    }
+
+    function pullTo(Token6 self, address benefactor, address recipient, UFixed18 amount, bool roundUp) external {
+        Token6Lib.pullTo(self, benefactor, recipient, amount, roundUp);
     }
 
     function name(Token6 self) external view returns (string memory) {
@@ -48,11 +64,11 @@ contract MockToken6 {
         return Token6Lib.symbol(self);
     }
 
-    function balanceOf(Token6 self) external view returns (UFixed6) {
+    function balanceOf(Token6 self) external view returns (UFixed18) {
         return Token6Lib.balanceOf(self);
     }
 
-    function balanceOf(Token6 self, address account) external view returns (UFixed6) {
+    function balanceOf(Token6 self, address account) external view returns (UFixed18) {
         return Token6Lib.balanceOf(self, account);
     }
 

--- a/contracts/token/types/Token6.sol
+++ b/contracts/token/types/Token6.sol
@@ -6,7 +6,6 @@ import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "../../number/types/UFixed18.sol";
-import "../../number/types/UFixed6.sol";
 
 /// @dev Token6
 type Token6 is address;
@@ -17,11 +16,14 @@ using Token6StorageLib for Token6Storage global;
 /**
  * @title Token6Lib
  * @notice Library to manage 6-decimal ERC20s that is compliant with the fixed-decimal types.
+ * @dev Automatically converts from Base-6 token amounts to Base-18 UFixed18 amounts, with optional rounding
  */
 library Token6Lib {
     using SafeERC20 for IERC20;
 
     Token6 public constant ZERO = Token6.wrap(address(0));
+
+    uint256 private constant OFFSET = 1e12;
 
     /**
      * @notice Returns whether a token is the zero address
@@ -64,8 +66,23 @@ library Token6Lib {
      * @param grantee Address to allow spending
      * @param amount Amount of tokens to approve to spend
      */
-    function approve(Token6 self, address grantee, UFixed6 amount) internal {
-        IERC20(Token6.unwrap(self)).safeApprove(grantee, UFixed6.unwrap(amount));
+    function approve(Token6 self, address grantee, UFixed18 amount) internal {
+        IERC20(Token6.unwrap(self)).safeApprove(grantee, toTokenAmount(amount, false));
+    }
+
+    /**
+     * @notice Approves `grantee` to spend `amount` tokens from the caller
+     * @dev There are important race conditions to be aware of when using this function
+            with values other than 0. This will revert if moving from non-zero to non-zero amounts
+            See https://github.com/OpenZeppelin/openzeppelin-contracts/blob/a55b7d13722e7ce850b626da2313f3e66ca1d101/contracts/token/ERC20/IERC20.sol#L57
+     * @param self Token to grant approval
+     * @param self Token to grant approval
+     * @param grantee Address to allow spending
+     * @param amount Amount of tokens to approve to spend
+     * @param roundUp Whether to round decimal token amount up to the next unit
+     */
+    function approve(Token6 self, address grantee, UFixed18 amount, bool roundUp) internal {
+        IERC20(Token6.unwrap(self)).safeApprove(grantee, toTokenAmount(amount, roundUp));
     }
 
     /**
@@ -83,8 +100,19 @@ library Token6Lib {
      * @param recipient Address to transfer tokens to
      * @param amount Amount of tokens to transfer
      */
-    function push(Token6 self, address recipient, UFixed6 amount) internal {
-        IERC20(Token6.unwrap(self)).safeTransfer(recipient, UFixed6.unwrap(amount));
+    function push(Token6 self, address recipient, UFixed18 amount) internal {
+        IERC20(Token6.unwrap(self)).safeTransfer(recipient, toTokenAmount(amount, false));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the caller to the `recipient`
+     * @param self Token to transfer
+     * @param recipient Address to transfer tokens to
+     * @param amount Amount of tokens to transfer
+     * @param roundUp Whether to round decimal token amount up to the next unit
+     */
+    function push(Token6 self, address recipient, UFixed18 amount, bool roundUp) internal {
+        IERC20(Token6.unwrap(self)).safeTransfer(recipient, toTokenAmount(amount, roundUp));
     }
 
     /**
@@ -94,8 +122,20 @@ library Token6Lib {
      * @param benefactor Address to transfer tokens from
      * @param amount Amount of tokens to transfer
      */
-    function pull(Token6 self, address benefactor, UFixed6 amount) internal {
-        IERC20(Token6.unwrap(self)).safeTransferFrom(benefactor, address(this), UFixed6.unwrap(amount));
+    function pull(Token6 self, address benefactor, UFixed18 amount) internal {
+        IERC20(Token6.unwrap(self)).safeTransferFrom(benefactor, address(this), toTokenAmount(amount, false));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the `benefactor` to the caller
+     * @dev Reverts if trying to pull Ether
+     * @param self Token to transfer
+     * @param benefactor Address to transfer tokens from
+     * @param amount Amount of tokens to transfer
+     * @param roundUp Whether to round decimal token amount up to the next unit
+     */
+    function pull(Token6 self, address benefactor, UFixed18 amount, bool roundUp) internal {
+        IERC20(Token6.unwrap(self)).safeTransferFrom(benefactor, address(this), toTokenAmount(amount, roundUp));
     }
 
     /**
@@ -106,8 +146,21 @@ library Token6Lib {
      * @param recipient Address to transfer tokens to
      * @param amount Amount of tokens to transfer
      */
-    function pullTo(Token6 self, address benefactor, address recipient, UFixed6 amount) internal {
-        IERC20(Token6.unwrap(self)).safeTransferFrom(benefactor, recipient, UFixed6.unwrap(amount));
+    function pullTo(Token6 self, address benefactor, address recipient, UFixed18 amount) internal {
+        IERC20(Token6.unwrap(self)).safeTransferFrom(benefactor, recipient, toTokenAmount(amount, false));
+    }
+
+    /**
+     * @notice Transfers `amount` tokens from the `benefactor` to `recipient`
+     * @dev Reverts if trying to pull Ether
+     * @param self Token to transfer
+     * @param benefactor Address to transfer tokens from
+     * @param recipient Address to transfer tokens to
+     * @param amount Amount of tokens to transfer
+     * @param roundUp Whether to round decimal token amount up to the next unit
+     */
+    function pullTo(Token6 self, address benefactor, address recipient, UFixed18 amount, bool roundUp) internal {
+        IERC20(Token6.unwrap(self)).safeTransferFrom(benefactor, recipient, toTokenAmount(amount, roundUp));
     }
 
     /**
@@ -133,7 +186,7 @@ library Token6Lib {
      * @param self Token to check for
      * @return Token balance of the caller
      */
-    function balanceOf(Token6 self) internal view returns (UFixed6) {
+    function balanceOf(Token6 self) internal view returns (UFixed18) {
         return balanceOf(self, address(this));
     }
 
@@ -143,8 +196,32 @@ library Token6Lib {
      * @param account Account to check
      * @return Token balance of the account
      */
-    function balanceOf(Token6 self, address account) internal view returns (UFixed6) {
-        return UFixed6.wrap(IERC20(Token6.unwrap(self)).balanceOf(account));
+    function balanceOf(Token6 self, address account) internal view returns (UFixed18) {
+        return fromTokenAmount(IERC20(Token6.unwrap(self)).balanceOf(account));
+    }
+
+    /**
+     * @notice Converts the unsigned fixed-decimal amount into the token amount according to
+     *         it's defined decimals
+     * @dev Provides the ability to "round up" the token amount which is useful in situations where
+     *      are swapping one token for another and don't want to give away "free" units due to rounding
+     *      errors in the favor of the user.
+     * @param amount Amount to convert
+     * @param roundUp Whether to round decimal token amount up to the next unit
+     * @return Normalized token amount
+     */
+    function toTokenAmount(UFixed18 amount, bool roundUp) private pure returns (uint256) {
+        return roundUp ? Math.ceilDiv(UFixed18.unwrap(amount), OFFSET) : UFixed18.unwrap(amount) / OFFSET;
+    }
+
+    /**
+     * @notice Converts the token amount into the unsigned fixed-decimal amount according to
+     *         it's defined decimals
+     * @param amount Token amount to convert
+     * @return Normalized unsigned fixed-decimal amount
+     */
+    function fromTokenAmount(uint256 amount) private pure returns (UFixed18) {
+        return UFixed18.wrap(amount * OFFSET);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "coverage": "hardhat coverage --testfiles './test/unit/**/*'",
     "lint": "eslint --fix --ext '.ts,.js' ./ && solhint 'contracts/**/*.sol' --fix",
     "format": "prettier -w .",
-    "postinstall": "yarn build",
+    "prepack": "yarn build",
     "prepare": "husky install",
     "clean": "rm -rf cache artifacts types/generated"
   },

--- a/test/unit/curve/JumpRateUtilizationCurve.test.ts
+++ b/test/unit/curve/JumpRateUtilizationCurve.test.ts
@@ -1,0 +1,212 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import HRE from 'hardhat'
+import { MockJumpRateUtilizationCurve, MockJumpRateUtilizationCurve__factory } from '../../../types/generated'
+
+const { ethers } = HRE
+
+const CURVE_1 = {
+  minRate: ethers.utils.parseEther('0.10'),
+  maxRate: ethers.utils.parseEther('1.00'),
+  targetRate: ethers.utils.parseEther('0.50'),
+  targetUtilization: ethers.utils.parseEther('0.80'),
+}
+
+const CURVE_2 = {
+  minRate: ethers.utils.parseEther('1.00'),
+  maxRate: ethers.utils.parseEther('1.00'),
+  targetRate: ethers.utils.parseEther('0.50'),
+  targetUtilization: ethers.utils.parseEther('0.80'),
+}
+
+const CURVE_3 = {
+  minRate: ethers.utils.parseEther('0.50'),
+  maxRate: ethers.utils.parseEther('0.50'),
+  targetRate: ethers.utils.parseEther('1.00'),
+  targetUtilization: ethers.utils.parseEther('0.80'),
+}
+
+const CURVE_4 = {
+  minRate: ethers.utils.parseEther('1.00'),
+  maxRate: ethers.utils.parseEther('0.10'),
+  targetRate: ethers.utils.parseEther('0.50'),
+  targetUtilization: ethers.utils.parseEther('0.80'),
+}
+
+const SLOT = ethers.utils.keccak256(Buffer.from('equilibria.root.JumpRateUtilizationCurve.testSlot'))
+
+describe('JumpRateUtilizationCurve', () => {
+  let user: SignerWithAddress
+  let jumpRateUtilizationCurve: MockJumpRateUtilizationCurve
+
+  beforeEach(async () => {
+    ;[user] = await ethers.getSigners()
+    jumpRateUtilizationCurve = await new MockJumpRateUtilizationCurve__factory(user).deploy()
+  })
+
+  describe('#compute', async () => {
+    context('CURVE_1', async () => {
+      it('returns correct rate at zero', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_1, ethers.utils.parseEther('0.00'))).to.equal(
+          ethers.utils.parseEther('0.10'),
+        )
+      })
+
+      it('returns correct rate below target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_1, ethers.utils.parseEther('0.40'))).to.equal(
+          ethers.utils.parseEther('0.30'),
+        )
+      })
+
+      it('returns correct rate at target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_1, ethers.utils.parseEther('0.80'))).to.equal(
+          ethers.utils.parseEther('0.50'),
+        )
+      })
+
+      it('returns correct rate above target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_1, ethers.utils.parseEther('0.90'))).to.equal(
+          ethers.utils.parseEther('0.75'),
+        )
+      })
+
+      it('returns correct rate at max', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_1, ethers.utils.parseEther('1.00'))).to.equal(
+          ethers.utils.parseEther('1.00'),
+        )
+      })
+
+      it('returns correct rate above max', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_1, ethers.utils.parseEther('1.10'))).to.equal(
+          ethers.utils.parseEther('1.00'),
+        )
+      })
+    })
+
+    context('CURVE_2', async () => {
+      it('returns correct rate at zero', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_2, ethers.utils.parseEther('0.00'))).to.equal(
+          ethers.utils.parseEther('1.00'),
+        )
+      })
+
+      it('returns correct rate below target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_2, ethers.utils.parseEther('0.40'))).to.equal(
+          ethers.utils.parseEther('0.75'),
+        )
+      })
+
+      it('returns correct rate at target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_2, ethers.utils.parseEther('0.80'))).to.equal(
+          ethers.utils.parseEther('0.50'),
+        )
+      })
+
+      it('returns correct rate above target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_2, ethers.utils.parseEther('0.90'))).to.equal(
+          ethers.utils.parseEther('0.75'),
+        )
+      })
+
+      it('returns correct rate at max', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_2, ethers.utils.parseEther('1.00'))).to.equal(
+          ethers.utils.parseEther('1.00'),
+        )
+      })
+
+      it('returns correct rate above max', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_2, ethers.utils.parseEther('1.10'))).to.equal(
+          ethers.utils.parseEther('1.00'),
+        )
+      })
+    })
+
+    context('CURVE_3', async () => {
+      it('returns correct rate at zero', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_3, ethers.utils.parseEther('0.00'))).to.equal(
+          ethers.utils.parseEther('0.50'),
+        )
+      })
+
+      it('returns correct rate below target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_3, ethers.utils.parseEther('0.40'))).to.equal(
+          ethers.utils.parseEther('0.75'),
+        )
+      })
+
+      it('returns correct rate at target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_3, ethers.utils.parseEther('0.80'))).to.equal(
+          ethers.utils.parseEther('1.00'),
+        )
+      })
+
+      it('returns correct rate above target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_3, ethers.utils.parseEther('0.90'))).to.equal(
+          ethers.utils.parseEther('0.75'),
+        )
+      })
+
+      it('returns correct rate at max', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_3, ethers.utils.parseEther('1.00'))).to.equal(
+          ethers.utils.parseEther('0.50'),
+        )
+      })
+
+      it('returns correct rate above max', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_3, ethers.utils.parseEther('1.10'))).to.equal(
+          ethers.utils.parseEther('0.50'),
+        )
+      })
+    })
+
+    context('CURVE_4', async () => {
+      it('returns correct rate at zero', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_4, ethers.utils.parseEther('0.00'))).to.equal(
+          ethers.utils.parseEther('1.00'),
+        )
+      })
+
+      it('returns correct rate below target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_4, ethers.utils.parseEther('0.40'))).to.equal(
+          ethers.utils.parseEther('0.75'),
+        )
+      })
+
+      it('returns correct rate at target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_4, ethers.utils.parseEther('0.80'))).to.equal(
+          ethers.utils.parseEther('0.50'),
+        )
+      })
+
+      it('returns correct rate above target', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_4, ethers.utils.parseEther('0.90'))).to.equal(
+          ethers.utils.parseEther('0.30'),
+        )
+      })
+
+      it('returns correct rate at max', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_4, ethers.utils.parseEther('1.00'))).to.equal(
+          ethers.utils.parseEther('0.10'),
+        )
+      })
+
+      it('returns correct rate above max', async () => {
+        expect(await jumpRateUtilizationCurve.compute(CURVE_4, ethers.utils.parseEther('1.10'))).to.equal(
+          ethers.utils.parseEther('0.10'),
+        )
+      })
+    })
+  })
+
+  describe('#store(JumpRateUtilizationCurve)', async () => {
+    it('sets value', async () => {
+      await jumpRateUtilizationCurve.store(SLOT, CURVE_1)
+
+      const storedCurve = await jumpRateUtilizationCurve.read(SLOT)
+      expect(storedCurve.minRate).to.equal(CURVE_1.minRate)
+      expect(storedCurve.maxRate).to.equal(CURVE_1.maxRate)
+      expect(storedCurve.targetRate).to.equal(CURVE_1.targetRate)
+      expect(storedCurve.targetUtilization).to.equal(CURVE_1.targetUtilization)
+    })
+  })
+})

--- a/test/unit/token/Token6.test.ts
+++ b/test/unit/token/Token6.test.ts
@@ -55,7 +55,53 @@ describe('Token6', () => {
 
       await token6
         .connect(user)
-        ['approve(address,address,uint256)'](erc20.address, recipient.address, utils.parseUnits('100', 6))
+        ['approve(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100'))
+    })
+
+    it('approves tokens (round down implicit)', async () => {
+      await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['approve(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100').add(1))
+    })
+
+    it('approves tokens (round down explicit)', async () => {
+      await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['approve(address,address,uint256,bool)'](
+          erc20.address,
+          recipient.address,
+          utils.parseEther('100').add(1),
+          false,
+        )
+    })
+
+    it('approves tokens (round up)', async () => {
+      await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, 100_000_001).returns(true)
+
+      await token6
+        .connect(user)
+        ['approve(address,address,uint256,bool)'](
+          erc20.address,
+          recipient.address,
+          utils.parseEther('100').add(1),
+          true,
+        )
+    })
+
+    it('approves tokens (round up when no decimal)', async () => {
+      await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(0)
+      await erc20.mock.approve.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['approve(address,address,uint256,bool)'](erc20.address, recipient.address, utils.parseEther('100'), true)
     })
 
     it('approves tokens all', async () => {
@@ -67,14 +113,14 @@ describe('Token6', () => {
 
     describe('with prior allowance', () => {
       beforeEach(async () => {
-        await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(utils.parseUnits('1', 6))
+        await erc20.mock.allowance.withArgs(token6.address, recipient.address).returns(utils.parseEther('1'))
       })
 
       it('reverts when approving for a specific amount', async () => {
         await expect(
           token6
             .connect(user)
-            ['approve(address,address,uint256)'](erc20.address, recipient.address, utils.parseUnits('100', 6)),
+            ['approve(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100')),
         ).to.be.reverted
       })
 
@@ -92,7 +138,39 @@ describe('Token6', () => {
 
       await token6
         .connect(user)
-        ['push(address,address,uint256)'](erc20.address, recipient.address, utils.parseUnits('100', 6))
+        ['push(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100'))
+    })
+
+    it('transfers tokens (round down implicit)', async () => {
+      await erc20.mock.transfer.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['push(address,address,uint256)'](erc20.address, recipient.address, utils.parseEther('100').add(1))
+    })
+
+    it('transfers tokens (round down explicit)', async () => {
+      await erc20.mock.transfer.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['push(address,address,uint256,bool)'](erc20.address, recipient.address, utils.parseEther('100').add(1), false)
+    })
+
+    it('transfers tokens (round up)', async () => {
+      await erc20.mock.transfer.withArgs(recipient.address, 100_000_001).returns(true)
+
+      await token6
+        .connect(user)
+        ['push(address,address,uint256,bool)'](erc20.address, recipient.address, utils.parseEther('100').add(1), true)
+    })
+
+    it('transfers tokens (round up when no decimal)', async () => {
+      await erc20.mock.transfer.withArgs(recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['push(address,address,uint256,bool)'](erc20.address, recipient.address, utils.parseEther('100'), true)
     })
 
     it('transfers tokens all', async () => {
@@ -107,7 +185,39 @@ describe('Token6', () => {
     it('transfers tokens', async () => {
       await erc20.mock.transferFrom.withArgs(user.address, token6.address, 100_000_000).returns(true)
 
-      await token6.connect(user).pull(erc20.address, user.address, utils.parseUnits('100', 6))
+      await token6.connect(user)['pull(address,address,uint256)'](erc20.address, user.address, utils.parseEther('100'))
+    })
+
+    it('transfers tokens (round down implicit)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, token6.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pull(address,address,uint256)'](erc20.address, user.address, utils.parseEther('100').add(1))
+    })
+
+    it('transfers tokens (round down explicit)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, token6.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pull(address,address,uint256,bool)'](erc20.address, user.address, utils.parseEther('100').add(1), false)
+    })
+
+    it('transfers tokens (round up)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, token6.address, 100_000_001).returns(true)
+
+      await token6
+        .connect(user)
+        ['pull(address,address,uint256,bool)'](erc20.address, user.address, utils.parseEther('100').add(1), true)
+    })
+
+    it('transfers tokens (round up when no decimal)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, token6.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pull(address,address,uint256,bool)'](erc20.address, user.address, utils.parseEther('100'), true)
     })
   })
 
@@ -115,7 +225,69 @@ describe('Token6', () => {
     it('transfers tokens', async () => {
       await erc20.mock.transferFrom.withArgs(user.address, recipient.address, 100_000_000).returns(true)
 
-      await token6.connect(user).pullTo(erc20.address, user.address, recipient.address, utils.parseUnits('100', 6))
+      await token6
+        .connect(user)
+        ['pullTo(address,address,address,uint256)'](
+          erc20.address,
+          user.address,
+          recipient.address,
+          utils.parseEther('100'),
+        )
+    })
+
+    it('transfers tokens (round down implicit)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pullTo(address,address,address,uint256)'](
+          erc20.address,
+          user.address,
+          recipient.address,
+          utils.parseEther('100').add(1),
+        )
+    })
+
+    it('transfers tokens (round down explicit)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pullTo(address,address,address,uint256,bool)'](
+          erc20.address,
+          user.address,
+          recipient.address,
+          utils.parseEther('100').add(1),
+          false,
+        )
+    })
+
+    it('transfers tokens (round up)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, recipient.address, 100_000_001).returns(true)
+
+      await token6
+        .connect(user)
+        ['pullTo(address,address,address,uint256,bool)'](
+          erc20.address,
+          user.address,
+          recipient.address,
+          utils.parseEther('100').add(1),
+          true,
+        )
+    })
+
+    it('transfers tokens (round up when no decimal)', async () => {
+      await erc20.mock.transferFrom.withArgs(user.address, recipient.address, 100_000_000).returns(true)
+
+      await token6
+        .connect(user)
+        ['pullTo(address,address,address,uint256,bool)'](
+          erc20.address,
+          user.address,
+          recipient.address,
+          utils.parseEther('100'),
+          true,
+        )
     })
   })
 
@@ -137,13 +309,13 @@ describe('Token6', () => {
     it('returns balance', async () => {
       await erc20.mock.balanceOf.withArgs(user.address).returns(100_000_000)
       expect(await token6.connect(user)['balanceOf(address,address)'](erc20.address, user.address)).to.equal(
-        utils.parseUnits('100', 6),
+        utils.parseEther('100'),
       )
     })
 
     it('returns balance all', async () => {
       await erc20.mock.balanceOf.withArgs(token6.address).returns(100_000_000)
-      expect(await token6.connect(user)['balanceOf(address)'](erc20.address)).to.equal(utils.parseUnits('100', 6))
+      expect(await token6.connect(user)['balanceOf(address)'](erc20.address)).to.equal(utils.parseEther('100'))
     })
   })
 


### PR DESCRIPTION
This change reverts v2 changes that make Root not backwards compatible. This allows us to include most of root v2 changes in the next comprehensive audit of Perennial v1.

Once we're ready for v2, we can revert this merge commit