### PR TITLE
Add accumulator zero check

### DIFF
--- a/contracts/accumulator/types/Accumulator6.sol
+++ b/contracts/accumulator/types/Accumulator6.sol
@@ -43,6 +43,7 @@ library Accumulator6Lib {
      * @param total Denominator of the ratio
      */
     function increment(Accumulator6 memory self, Fixed6 amount, UFixed6 total) internal pure {
+        if (amount.isZero()) return;
         self._value = self._value.add(_div(amount, total));
     }
 
@@ -54,6 +55,7 @@ library Accumulator6Lib {
      * @param total Denominator of the ratio
      */
     function decrement(Accumulator6 memory self, Fixed6 amount, UFixed6 total) internal pure {
+        if (amount.isZero()) return;
         self._value = self._value.add(_div(amount.mul(Fixed6Lib.NEG_ONE), total));
     }
 

--- a/contracts/accumulator/types/UAccumulator6.sol
+++ b/contracts/accumulator/types/UAccumulator6.sol
@@ -41,6 +41,7 @@ library UAccumulator6Lib {
      * @param total Denominator of the ratio
      */
     function increment(UAccumulator6 memory self, UFixed6 amount, UFixed6 total) internal pure {
+        if (amount.isZero()) return;
         self._value = self._value.add(amount.div(total));
     }
 }

--- a/test/unit/accumulator/Accumulator6.test.ts
+++ b/test/unit/accumulator/Accumulator6.test.ts
@@ -36,6 +36,20 @@ describe('Accumulator6', () => {
       await accumulator6.increment(-1, utils.parseUnits('2', 6))
       expect(await value(accumulator6)).to.equal(-1)
     })
+
+    it('zero amount / non-zero total', async () => {
+      await accumulator6.increment(utils.parseUnits('0', 6), utils.parseUnits('1', 6))
+      expect(await value(accumulator6)).to.equal(utils.parseUnits('0', 6))
+    })
+
+    it('zero amount / zero total', async () => {
+      await accumulator6.increment(utils.parseUnits('0', 6), utils.parseUnits('0', 6))
+      expect(await value(accumulator6)).to.equal(utils.parseUnits('0', 6))
+    })
+
+    it('non-zero amount / zero total (reverts)', async () => {
+      await expect(accumulator6.increment(utils.parseUnits('1', 6), utils.parseUnits('0', 6))).to.revertedWith('0x12')
+    })
   })
 
   describe('#decrement', async () => {
@@ -53,6 +67,22 @@ describe('Accumulator6', () => {
 
       await accumulator6.decrement(1, utils.parseUnits('2', 6))
       expect(await value(accumulator6)).to.equal(-1)
+    })
+
+    it('zero amount / non-zero total', async () => {
+      await accumulator6.decrement(utils.parseUnits('0', 6), utils.parseUnits('1', 6))
+      expect(await value(accumulator6)).to.equal(utils.parseUnits('0', 6))
+    })
+
+    it('zero amount / zero total', async () => {
+      await accumulator6.decrement(utils.parseUnits('0', 6), utils.parseUnits('0', 6))
+      expect(await value(accumulator6)).to.equal(utils.parseUnits('0', 6))
+    })
+
+    it('non-zero amount / zero total (reverts)', async () => {
+      await expect(accumulator6.decrement(utils.parseUnits('1', 6), utils.parseUnits('0', 6))).to.revertedWith(
+        'DivisionByZero()',
+      )
     })
   })
 

--- a/test/unit/accumulator/UAccumulator6.test.ts
+++ b/test/unit/accumulator/UAccumulator6.test.ts
@@ -30,6 +30,20 @@ describe('Accumulator6', () => {
       await accumulator6.increment(1, utils.parseUnits('2', 6))
       expect(await value(accumulator6)).to.equal(0)
     })
+
+    it('zero amount / non-zero total', async () => {
+      await accumulator6.increment(utils.parseUnits('0', 6), utils.parseUnits('1', 6))
+      expect(await value(accumulator6)).to.equal(utils.parseUnits('0', 6))
+    })
+
+    it('zero amount / zero total', async () => {
+      await accumulator6.increment(utils.parseUnits('0', 6), utils.parseUnits('0', 6))
+      expect(await value(accumulator6)).to.equal(utils.parseUnits('0', 6))
+    })
+
+    it('non-zero amount / zero total (reverts)', async () => {
+      await expect(accumulator6.increment(utils.parseUnits('1', 6), utils.parseUnits('0', 6))).to.revertedWith('0x12')
+    })
   })
 
   describe('#accumulated', async () => {


### PR DESCRIPTION
Currently the accumulator will always reverts with a divide-by-zero error when increment / decrementing with a zero value `total`.

This PR adds a check that allows the case of a zero-value `amount` being able to be used with a zero-value `total`.

This case is *correct* because no value is being distributed to no one, where as we would still want the case of some value being distributed to no one to revert since this can cause silent burning of assets.