### PR TITLE
Improve Kept

### DIFF
--- a/contracts/attribute/Kept/Kept.sol
+++ b/contracts/attribute/Kept/Kept.sol
@@ -33,16 +33,23 @@ abstract contract Kept is IKept, Initializable {
     /// @param data Arbitrary data passed in from the keep modifier
     function _raiseKeeperFee(UFixed18 amount, bytes memory data) internal virtual { }
 
-    // TODO
-    /// @dev Hook for inheriting contracts to perform logic to calculate the dynamic fee
-    /// @param applicableCalldata The calldata that will be used to price the dynamic fee
+    /// @notice Computes the calldata portion of the keeper fee
+    /// @dev Used for L2 implementation with significant calldata costs
+    /// @param applicableCalldata The applicable calldata
+    /// @param multiplierCalldata The multiplier to apply to the calldata cost
+    /// @param bufferCalldata The buffer to apply to the calldata cost
+    /// @return The calldata portion of the keeper fee
     function _calldataFee(
         bytes calldata applicableCalldata,
         UFixed18 multiplierCalldata,
         uint256 bufferCalldata
     ) internal view virtual returns (UFixed18) { return UFixed18Lib.ZERO; }
 
-    // TODO
+    /// @notice Computes the base gas portion of the keeper fee
+    /// @param applicableGas The applicable gas cost
+    /// @param multiplierBase The multiplier to apply to the gas cost
+    /// @param bufferBase The buffer to apply to the gas cost
+    /// @return The gas cost portion of the keeper fee
     function _baseFee(
         uint256 applicableGas,
         UFixed18 multiplierBase,
@@ -51,6 +58,12 @@ abstract contract Kept is IKept, Initializable {
         return _fee(applicableGas, multiplierBase, bufferBase, block.basefee);
     }
 
+    /// @notice Computes a generic keeper fee based on parameters
+    /// @dev Helper function to consolidate keeper fee computation logic
+    /// @param gas The gas cost
+    /// @param multiplier The multiplier to apply to the gas cost
+    /// @param buffer The buffer to apply to the gas cost
+    /// @return The resulting keeper fee
     function _fee(uint256 gas, UFixed18 multiplier, uint256 buffer, uint256 baseFee) internal pure returns (UFixed18) {
         return UFixed18Lib.from(gas).mul(multiplier).add(UFixed18Lib.from(buffer)).mul(UFixed18.wrap(baseFee));
     }

--- a/contracts/attribute/Kept/Kept.sol
+++ b/contracts/attribute/Kept/Kept.sol
@@ -33,31 +33,52 @@ abstract contract Kept is IKept, Initializable {
     /// @param data Arbitrary data passed in from the keep modifier
     function _raiseKeeperFee(UFixed18 amount, bytes memory data) internal virtual { }
 
+    // TODO
     /// @dev Hook for inheriting contracts to perform logic to calculate the dynamic fee
-    /// @param callData The calldata that will be used to price the dynamic fee
-    function _calculateDynamicFee(bytes memory callData) internal view virtual returns (UFixed18) { }
+    /// @param applicableCalldata The calldata that will be used to price the dynamic fee
+    function _calldataFee(
+        bytes calldata applicableCalldata,
+        UFixed18 multiplierCalldata,
+        uint256 bufferCalldata
+    ) internal view virtual returns (UFixed18) { return UFixed18Lib.ZERO; }
 
-    /// @notice Placed on a functon to incentivize keepers to call it
-    /// @param multiplier The multiplier to apply to the gas used
-    /// @param buffer The fixed gas amount to add to the gas used
+    // TODO
+    function _baseFee(
+        uint256 applicableGas,
+        UFixed18 multiplierBase,
+        uint256 bufferBase
+    ) internal view returns (UFixed18) {
+        return _fee(applicableGas, multiplierBase, bufferBase, block.basefee);
+    }
+
+    function _fee(uint256 gas, UFixed18 multiplier, uint256 buffer, uint256 baseFee) internal pure returns (UFixed18) {
+        return UFixed18Lib.from(gas).mul(multiplier).add(UFixed18Lib.from(buffer)).mul(UFixed18.wrap(baseFee));
+    }
+
+    /// @notice Placed on a function to incentivize keepers to call it
+    /// @param config The multiplier and buffer configuration to apply
     /// @param data Arbitrary data to pass to the _raiseKeeperFee function
-    modifier keep(UFixed18 multiplier, uint256 buffer, bytes memory dynamicCalldata, bytes memory data) {
+    modifier keep(
+        KeepConfig memory config,
+        bytes calldata applicableCalldata,
+        uint256 applicableValue,
+        bytes memory data
+    ) {
         uint256 startGas = gasleft();
 
         _;
 
-        uint256 gasUsed = startGas - gasleft();
-        UFixed18 keeperFee = UFixed18Lib.from(gasUsed)
-            .mul(multiplier)
-            .add(UFixed18Lib.from(buffer))
-            .mul(UFixed18.wrap(block.basefee))
-            .add(_calculateDynamicFee(dynamicCalldata))
-            .mul(_etherPrice());
-        _raiseKeeperFee(keeperFee, data);
+        uint256 applicableGas = startGas - gasleft();
+        (UFixed18 baseFee, UFixed18 calldataFee) = (
+            _baseFee(applicableGas, config.multiplierBase, config.bufferBase),
+            _calldataFee(applicableCalldata, config.multiplierCalldata, config.bufferCalldata)
+        );
 
+        UFixed18 keeperFee = UFixed18.wrap(applicableValue).add(baseFee).add(calldataFee).mul(_etherPrice());
+        _raiseKeeperFee(keeperFee, data);
         keeperToken().push(msg.sender, keeperFee);
 
-        emit KeeperCall(msg.sender, gasUsed, multiplier, buffer, keeperFee);
+        emit KeeperCall(msg.sender, applicableGas, applicableValue, baseFee, calldataFee, keeperFee);
     }
 
     /// @notice Returns the price of ETH in terms of the keeper token

--- a/contracts/attribute/Kept/Kept_Arbitrum.sol
+++ b/contracts/attribute/Kept/Kept_Arbitrum.sol
@@ -18,9 +18,16 @@ abstract contract Kept_Arbitrum is Kept {
     // https://docs.arbitrum.io/devs-how-tos/how-to-estimate-gas#breaking-down-the-formula
     // Tx Fee = block.baseFee * l2GasUsed + ArbGasInfo.getL1BaseFeeEstimate() * 16 * (calldataLength + fixedOverhead)
     // Dynamic buffer = (ArbGasInfo.getL1BaseFeeEstimate() * 16 * (calldataLength + fixedOverhead))
-    function _calculateDynamicFee(bytes memory callData) internal view virtual override returns (UFixed18) {
-        return UFixed18.wrap(
-            ARB_GAS.getL1BaseFeeEstimate() * ARB_GAS_MULTIPLIER * (callData.length + ARB_FIXED_OVERHEAD)
+    function _calldataFee(
+        bytes calldata applicableCalldata,
+        UFixed18 multiplierCalldata,
+        uint256 bufferCalldata
+    ) internal view virtual override returns (UFixed18) {
+        return _fee(
+            ARB_GAS_MULTIPLIER * (applicableCalldata.length + ARB_FIXED_OVERHEAD),
+            multiplierCalldata,
+            bufferCalldata,
+            ARB_GAS.getL1BaseFeeEstimate()
         );
     }
 }

--- a/contracts/attribute/Kept/Kept_Optimism.sol
+++ b/contracts/attribute/Kept/Kept_Optimism.sol
@@ -4,7 +4,10 @@ pragma solidity ^0.8.13;
 import "./Kept.sol";
 
 interface OptGasInfo {
-    function getL1Fee(bytes memory) external view returns (uint256);
+    function getL1GasUsed(bytes memory) external view returns (uint256);
+    function l1BaseFee() external view returns (uint256);
+    function scalar() external view returns (uint256);
+    function decimals() external view returns (uint256);
 }
 
 /// @dev Optimism Kept implementation
@@ -13,8 +16,17 @@ abstract contract Kept_Optimism is Kept {
     OptGasInfo constant OPT_GAS = OptGasInfo(0x420000000000000000000000000000000000000F);
 
     // https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee
-    // The getL1Fee method takes into account L1 gas price, size, and overhead values
-    function _calculateDynamicFee(bytes memory callData) internal view virtual override returns (UFixed18) {
-        return UFixed18.wrap(OPT_GAS.getL1Fee(callData));
+    // Adds a buffer to the L1 gas used to account for the overhead of the transaction
+    function _calldataFee(
+        bytes calldata applicableCalldata,
+        UFixed18 multiplierCalldata,
+        uint256 bufferCalldata
+    ) internal view virtual override returns (UFixed18) {
+        return _fee(
+            OPT_GAS.getL1GasUsed(applicableCalldata),
+            multiplierCalldata,
+            bufferCalldata,
+            OPT_GAS.l1BaseFee() * OPT_GAS.scalar() / (10 ** OPT_GAS.decimals())
+        );
     }
 }

--- a/contracts/attribute/interfaces/IKept.sol
+++ b/contracts/attribute/interfaces/IKept.sol
@@ -7,7 +7,14 @@ import "../../number/types/UFixed18.sol";
 import "../../token/types/Token18.sol";
 
 interface IKept is IInitializable {
-    event KeeperCall(address indexed sender, uint256 gasUsed, UFixed18 multiplier, uint256 buffer, UFixed18 keeperFee);
+    struct KeepConfig {
+        UFixed18 multiplierBase;
+        uint256 bufferBase;
+        UFixed18 multiplierCalldata;
+        uint256 bufferCalldata;
+    }
+
+    event KeeperCall(address indexed sender, uint256 applicableGas, uint256 applicableValue, UFixed18 baseFee, UFixed18 calldataFee, UFixed18 keeperFee);
 
     function ethTokenOracleFeed() external view returns (AggregatorV3Interface);
     function keeperToken() external view returns (Token18);

--- a/contracts/mocks/MockKept.sol
+++ b/contracts/mocks/MockKept.sol
@@ -22,7 +22,10 @@ contract MockKept is Kept {
         keeperToken().pull(benefactor, amount);
     }
 
-    function toBeKept(UFixed18 multiplier, uint256 buffer, bytes memory data) keep(multiplier, buffer, "", data) external {}
+    function toBeKept(UFixed18 multiplier, uint256 buffer, uint256 value, bytes memory data)
+        external
+        keep(KeepConfig(multiplier, buffer, UFixed18Lib.ZERO, 0), msg.data[0:0], value, data)
+    { }
 
     /// @dev This function is used to figure out what gasUsed is. We can't hardcode this
     /// @dev in tests because it depends on whether we're running coverage or not.
@@ -32,5 +35,5 @@ contract MockKept is Kept {
         return startGas - gasleft() - 24;
     }
 
-    function emptyFunc() internal {}
+    function emptyFunc() internal { }
 }

--- a/contracts/mocks/MockKept_Arbitrum.sol
+++ b/contracts/mocks/MockKept_Arbitrum.sol
@@ -23,11 +23,17 @@ contract MockKept_Arbitrum is Kept_Arbitrum {
     }
 
     function toBeKept(
-        UFixed18 multiplier,
-        uint256 buffer,
-        bytes memory payload,
+        UFixed18 multiplierBase,
+        uint256 bufferBase,
+        UFixed18 multiplierCalldata,
+        uint256 bufferCalldata,
+        bytes calldata applicableCalldata,
+        uint256 value,
         bytes memory data
-    ) external keep(multiplier, buffer, payload, data) {}
+    )
+        external
+        keep(KeepConfig(multiplierBase, bufferBase, multiplierCalldata, bufferCalldata), applicableCalldata, value, data)
+    { }
 
     /// @dev This function is used to figure out what gasUsed is. We can't hardcode this
     /// @dev in tests because it depends on whether we're running coverage or not.

--- a/contracts/mocks/MockKept_Optimism.sol
+++ b/contracts/mocks/MockKept_Optimism.sol
@@ -23,11 +23,17 @@ contract MockKept_Optimism is Kept_Optimism {
     }
 
     function toBeKept(
-        UFixed18 multiplier,
-        uint256 buffer,
-        bytes memory payload,
+        UFixed18 multiplierBase,
+        uint256 bufferBase,
+        UFixed18 multiplierCalldata,
+        uint256 bufferCalldata,
+        bytes calldata applicableCalldata,
+        uint256 value,
         bytes memory data
-    ) external keep(multiplier, buffer, payload, data) {}
+    )
+        external
+        keep(KeepConfig(multiplierBase, bufferBase, multiplierCalldata, bufferCalldata), applicableCalldata, value, data)
+    { }
 
     /// @dev This function is used to figure out what gasUsed is. We can't hardcode this
     /// @dev in tests because it depends on whether we're running coverage or not.


### PR DESCRIPTION
Improves the accounting of `Kept`'s `keep` modifier by adding the following functionality:
- Splits `multiplier` / `buffer` into two sets: one for the base fee, and one for the calldata fee (optionally used in L2 implementations)
- Adds an `applicableValue` field to account for Ether passed in to pay for the function call.