### PR TITLE
Add unsafeSub / unsafeFrom

### DIFF
--- a/contracts/mocks/MockUFixed18.sol
+++ b/contracts/mocks/MockUFixed18.sol
@@ -21,6 +21,10 @@ contract MockUFixed18 {
         return UFixed18Lib.from(a);
     }
 
+    function unsafeFrom(Fixed18 a) external pure returns (UFixed18) {
+        return UFixed18Lib.unsafeFrom(a);
+    }
+
     function from(uint256 a) external pure returns (UFixed18) {
         return UFixed18Lib.from(a);
     }
@@ -39,6 +43,10 @@ contract MockUFixed18 {
 
     function sub(UFixed18 a, UFixed18 b) external pure returns (UFixed18) {
         return UFixed18Lib.sub(a, b);
+    }
+
+    function unsafeSub(UFixed18 a, UFixed18 b) external pure returns (UFixed18) {
+        return UFixed18Lib.unsafeSub(a, b);
     }
 
     function mul(UFixed18 a, UFixed18 b) external pure returns (UFixed18) {

--- a/contracts/mocks/MockUFixed6.sol
+++ b/contracts/mocks/MockUFixed6.sol
@@ -20,6 +20,10 @@ contract MockUFixed6 {
         return UFixed6Lib.from(a);
     }
 
+    function unsafeFrom(Fixed6 a) external pure returns (UFixed6) {
+        return UFixed6Lib.unsafeFrom(a);
+    }
+
     function from(uint256 a) external pure returns (UFixed6) {
         return UFixed6Lib.from(a);
     }
@@ -42,6 +46,10 @@ contract MockUFixed6 {
 
     function sub(UFixed6 a, UFixed6 b) external pure returns (UFixed6) {
         return UFixed6Lib.sub(a, b);
+    }
+
+    function unsafeSub(UFixed6 a, UFixed6 b) external pure returns (UFixed6) {
+        return UFixed6Lib.unsafeSub(a, b);
     }
 
     function mul(UFixed6 a, UFixed6 b) external pure returns (UFixed6) {

--- a/contracts/number/types/UFixed18.sol
+++ b/contracts/number/types/UFixed18.sol
@@ -36,6 +36,17 @@ library UFixed18Lib {
     }
 
     /**
+     * @notice Creates a unsigned fixed-decimal from a signed fixed-decimal
+     * @dev Does not revert on underflow, instead returns `ZERO`
+     * @param a Signed fixed-decimal
+     * @return New unsigned fixed-decimal
+     */
+    function unsafeFrom(Fixed18 a) internal pure returns (UFixed18) {
+        int256 value = Fixed18.unwrap(a);
+        return (value < 0) ? ZERO : UFixed18.wrap(uint256(value));
+    }
+
+    /**
      * @notice Creates a unsigned fixed-decimal from a unsigned integer
      * @param a Unsigned number
      * @return New unsigned fixed-decimal
@@ -80,6 +91,17 @@ library UFixed18Lib {
      */
     function sub(UFixed18 a, UFixed18 b) internal pure returns (UFixed18) {
         return UFixed18.wrap(UFixed18.unwrap(a) - UFixed18.unwrap(b));
+    }
+
+    /**
+     * @notice Subtracts unsigned fixed-decimal `a` by `b`
+     * @dev Does not revert on underflow, instead returns `ZERO`
+     * @param a Unsigned fixed-decimal to subtract from
+     * @param b Unsigned fixed-decimal to subtract
+     * @return Resulting subtracted unsigned fixed-decimal
+     */
+    function unsafeSub(UFixed18 a, UFixed18 b) internal pure returns (UFixed18) {
+        return gt(b, a) ? ZERO : sub(a, b);
     }
 
     /**

--- a/contracts/number/types/UFixed18.sol
+++ b/contracts/number/types/UFixed18.sol
@@ -42,8 +42,7 @@ library UFixed18Lib {
      * @return New unsigned fixed-decimal
      */
     function unsafeFrom(Fixed18 a) internal pure returns (UFixed18) {
-        int256 value = Fixed18.unwrap(a);
-        return (value < 0) ? ZERO : UFixed18.wrap(uint256(value));
+        return a.lt(Fixed18Lib.ZERO) ? ZERO : from(a);
     }
 
     /**

--- a/contracts/number/types/UFixed6.sol
+++ b/contracts/number/types/UFixed6.sol
@@ -42,8 +42,7 @@ library UFixed6Lib {
      * @return New unsigned fixed-decimal
      */
     function unsafeFrom(Fixed6 a) internal pure returns (UFixed6) {
-        int256 value = Fixed6.unwrap(a);
-        return (value < 0) ? ZERO : UFixed6.wrap(uint256(value));
+        return a.lt(Fixed6Lib.ZERO) ? ZERO : from(a);
     }
 
     /**

--- a/contracts/number/types/UFixed6.sol
+++ b/contracts/number/types/UFixed6.sol
@@ -36,6 +36,17 @@ library UFixed6Lib {
     }
 
     /**
+     * @notice Creates a unsigned fixed-decimal from a signed fixed-decimal
+     * @dev Does not revert on underflow, instead returns `ZERO`
+     * @param a Signed fixed-decimal
+     * @return New unsigned fixed-decimal
+     */
+    function unsafeFrom(Fixed6 a) internal pure returns (UFixed6) {
+        int256 value = Fixed6.unwrap(a);
+        return (value < 0) ? ZERO : UFixed6.wrap(uint256(value));
+    }
+
+    /**
      * @notice Creates a unsigned fixed-decimal from a unsigned integer
      * @param a Unsigned number
      * @return New unsigned fixed-decimal
@@ -90,6 +101,17 @@ library UFixed6Lib {
      */
     function sub(UFixed6 a, UFixed6 b) internal pure returns (UFixed6) {
         return UFixed6.wrap(UFixed6.unwrap(a) - UFixed6.unwrap(b));
+    }
+
+    /**
+     * @notice Subtracts unsigned fixed-decimal `a` by `b`
+     * @dev Does not revert on underflow, instead returns `ZERO`
+     * @param a Unsigned fixed-decimal to subtract from
+     * @param b Unsigned fixed-decimal to subtract
+     * @return Resulting subtracted unsigned fixed-decimal
+     */
+    function unsafeSub(UFixed6 a, UFixed6 b) internal pure returns (UFixed6) {
+        return gt(b, a) ? ZERO : sub(a, b);
     }
 
     /**

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "2.1.0",
+  "version": "2.2.0-rc0",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"

--- a/test/unit/number/UFixed18.test.ts
+++ b/test/unit/number/UFixed18.test.ts
@@ -54,6 +54,16 @@ describe('UFixed18', () => {
     })
   })
 
+  describe('#unsafeFrom(Fixed18)', async () => {
+    it('creates positive', async () => {
+      expect(await uFixed18.unsafeFrom(utils.parseEther('10'))).to.equal(utils.parseEther('10'))
+    })
+
+    it('reverts if negative', async () => {
+      expect(await uFixed18.unsafeFrom(utils.parseEther('-10'))).to.equal(utils.parseEther('0'))
+    })
+  })
+
   describe('#from(UFixed6)', async () => {
     it('creates new', async () => {
       expect(await uFixed18.fromUFixed6(utils.parseUnits('10', 6))).to.equal(utils.parseEther('10'))
@@ -84,6 +94,16 @@ describe('UFixed18', () => {
   describe('#sub', async () => {
     it('subs', async () => {
       expect(await uFixed18.sub(20, 10)).to.equal(10)
+    })
+  })
+
+  describe('#unsafeSub', async () => {
+    it('subs', async () => {
+      expect(await uFixed18.unsafeSub(20, 10)).to.equal(10)
+    })
+
+    it('zero if underflow', async () => {
+      expect(await uFixed18.unsafeSub(10, 20)).to.equal(0)
     })
   })
 

--- a/test/unit/number/UFixed6.test.ts
+++ b/test/unit/number/UFixed6.test.ts
@@ -54,6 +54,16 @@ describe('UFixed6', () => {
     })
   })
 
+  describe('#fromUnsafe(Fixed6)', async () => {
+    it('creates positive', async () => {
+      expect(await uFixed6.unsafeFrom(utils.parseUnits('10', 6))).to.equal(utils.parseUnits('10', 6))
+    })
+
+    it('zero if negative', async () => {
+      expect(await uFixed6.unsafeFrom(utils.parseUnits('-10', 6))).to.equal(utils.parseUnits('0', 6))
+    })
+  })
+
   describe('#from(UFixed18)', async () => {
     it('creates new (no rounding)', async () => {
       expect(await uFixed6['fromBase18(uint256)'](utils.parseEther('10.1'))).to.equal(utils.parseUnits('10.1', 6))
@@ -101,6 +111,16 @@ describe('UFixed6', () => {
   describe('#sub', async () => {
     it('subs', async () => {
       expect(await uFixed6.sub(20, 10)).to.equal(10)
+    })
+  })
+
+  describe('#unsafeSub', async () => {
+    it('subs', async () => {
+      expect(await uFixed6.unsafeSub(20, 10)).to.equal(10)
+    })
+
+    it('zero if underflow', async () => {
+      expect(await uFixed6.unsafeSub(10, 20)).to.equal(0)
     })
   })
 


### PR DESCRIPTION
Adds two new `unsafe` functions to `UFixed` number types:
- `unsafeFrom`: defaults to `ZERO` instead of reverting with a negative input.
- `unsafeSub`: returns `ZERO` instead of underflowing when the result would be negative.