### PR TITLE
Add unsafeMuldiv

### DIFF
--- a/contracts/mocks/MockUFixed18.sol
+++ b/contracts/mocks/MockUFixed18.sol
@@ -89,6 +89,22 @@ contract MockUFixed18 {
         return UFixed18Lib.muldivOut(a, b, c);
     }
 
+    function unsafeMuldiv1(UFixed18 a, uint256 b, uint256 c) external pure returns (UFixed18) {
+        return UFixed18Lib.unsafeMuldiv(a, b, c);
+    }
+
+    function unsafeMuldivOut1(UFixed18 a, uint256 b, uint256 c) external pure returns (UFixed18) {
+        return UFixed18Lib.unsafeMuldivOut(a, b, c);
+    }
+
+    function unsafeMuldiv2(UFixed18 a, UFixed18 b, UFixed18 c) external pure returns (UFixed18) {
+        return UFixed18Lib.unsafeMuldiv(a, b, c);
+    }
+
+    function unsafeMuldivOut2(UFixed18 a, UFixed18 b, UFixed18 c) external pure returns (UFixed18) {
+        return UFixed18Lib.unsafeMuldivOut(a, b, c);
+    }
+
     function eq(UFixed18 a, UFixed18 b) external pure returns (bool) {
         return UFixed18Lib.eq(a, b);
     }

--- a/contracts/mocks/MockUFixed6.sol
+++ b/contracts/mocks/MockUFixed6.sol
@@ -92,6 +92,22 @@ contract MockUFixed6 {
         return UFixed6Lib.muldivOut(a, b, c);
     }
 
+    function unsafeMuldiv1(UFixed6 a, uint256 b, uint256 c) external pure returns (UFixed6) {
+        return UFixed6Lib.unsafeMuldiv(a, b, c);
+    }
+
+    function unsafeMuldivOut1(UFixed6 a, uint256 b, uint256 c) external pure returns (UFixed6) {
+        return UFixed6Lib.unsafeMuldivOut(a, b, c);
+    }
+
+    function unsafeMuldiv2(UFixed6 a, UFixed6 b, UFixed6 c) external pure returns (UFixed6) {
+        return UFixed6Lib.unsafeMuldiv(a, b, c);
+    }
+
+    function unsafeMuldivOut2(UFixed6 a, UFixed6 b, UFixed6 c) external pure returns (UFixed6) {
+        return UFixed6Lib.unsafeMuldivOut(a, b, c);
+    }
+
     function eq(UFixed6 a, UFixed6 b) external pure returns (bool) {
         return UFixed6Lib.eq(a, b);
     }

--- a/contracts/number/types/UFixed18.sol
+++ b/contracts/number/types/UFixed18.sol
@@ -219,6 +219,62 @@ library UFixed18Lib {
     }
 
     /**
+     * @notice Computes a * b / c without loss of precision due to BASE conversion
+     * @dev Does not revert on divide-by-0, instead returns `ONE` for `0/0` and `MAX` for `n/0`.
+     * @param a First unsigned fixed-decimal
+     * @param b Unsigned number to multiply by
+     * @param c Unsigned number to divide by
+     * @return Resulting computation
+     */
+    function unsafeMuldiv(UFixed18 a, uint256 b, uint256 c) internal pure returns (UFixed18) {
+        return unsafeMuldiv(a, UFixed18.wrap(b), UFixed18.wrap(c));
+    }
+
+    /**
+     * @notice Computes a * b / c without loss of precision due to BASE conversion, rounding the result up to the next integer if there is a remainder
+     * @dev Does not revert on divide-by-0, instead returns `ONE` for `0/0` and `MAX` for `n/0`.
+     * @param a First unsigned fixed-decimal
+     * @param b Unsigned number to multiply by
+     * @param c Unsigned number to divide by
+     * @return Resulting computation
+     */
+    function unsafeMuldivOut(UFixed18 a, uint256 b, uint256 c) internal pure returns (UFixed18) {
+        return unsafeMuldivOut(a, UFixed18.wrap(b), UFixed18.wrap(c));
+    }
+
+    /**
+     * @notice Computes a * b / c without loss of precision due to BASE conversion
+     * @dev Does not revert on divide-by-0, instead returns `ONE` for `0/0` and `MAX` for `n/0`.
+     * @param a First unsigned fixed-decimal
+     * @param b Unsigned fixed-decimal to multiply by
+     * @param c Unsigned fixed-decimal to divide by
+     * @return Resulting computation
+     */
+    function unsafeMuldiv(UFixed18 a, UFixed18 b, UFixed18 c) internal pure returns (UFixed18) {
+        if (isZero(c)) {
+            return (isZero(a) || isZero(b)) ? ONE : MAX;
+        } else {
+            return muldiv(a, b, c);
+        }
+    }
+
+    /**
+     * @notice Computes a * b / c without loss of precision due to BASE conversion, rounding the result up to the next integer if there is a remainder
+     * @dev Does not revert on divide-by-0, instead returns `ONE` for `0/0` and `MAX` for `n/0`.
+     * @param a First unsigned fixed-decimal
+     * @param b Unsigned fixed-decimal to multiply by
+     * @param c Unsigned fixed-decimal to divide by
+     * @return Resulting computation
+     */
+    function unsafeMuldivOut(UFixed18 a, UFixed18 b, UFixed18 c) internal pure returns (UFixed18) {
+        if (isZero(c)) {
+            return (isZero(a) || isZero(b)) ? ONE : MAX;
+        } else {
+            return muldivOut(a, b, c);
+        }
+    }
+
+    /**
      * @notice Returns whether unsigned fixed-decimal `a` is equal to `b`
      * @param a First unsigned fixed-decimal
      * @param b Second unsigned fixed-decimal

--- a/contracts/number/types/UFixed6.sol
+++ b/contracts/number/types/UFixed6.sol
@@ -205,7 +205,6 @@ library UFixed6Lib {
         return muldivOut(a, UFixed6.wrap(b), UFixed6.wrap(c));
     }
 
-
     /**
      * @notice Computes a * b / c without loss of precision due to BASE conversion
      * @param a First unsigned fixed-decimal
@@ -226,6 +225,62 @@ library UFixed6Lib {
      */
     function muldivOut(UFixed6 a, UFixed6 b, UFixed6 c) internal pure returns (UFixed6) {
         return UFixed6.wrap(NumberMath.divOut(UFixed6.unwrap(a) * UFixed6.unwrap(b), UFixed6.unwrap(c)));
+    }
+
+    /**
+     * @notice Computes a * b / c without loss of precision due to BASE conversion
+     * @dev Does not revert on divide-by-0, instead returns `ONE` for `0/0` and `MAX` for `n/0`.
+     * @param a First unsigned fixed-decimal
+     * @param b Unsigned number to multiply by
+     * @param c Unsigned number to divide by
+     * @return Resulting computation
+     */
+    function unsafeMuldiv(UFixed6 a, uint256 b, uint256 c) internal pure returns (UFixed6) {
+        return unsafeMuldiv(a, UFixed6.wrap(b), UFixed6.wrap(c));
+    }
+
+    /**
+     * @notice Computes a * b / c without loss of precision due to BASE conversion, rounding the result up to the next integer if there is a remainder
+     * @dev Does not revert on divide-by-0, instead returns `ONE` for `0/0` and `MAX` for `n/0`.
+     * @param a First unsigned fixed-decimal
+     * @param b Unsigned number to multiply by
+     * @param c Unsigned number to divide by
+     * @return Resulting computation
+     */
+    function unsafeMuldivOut(UFixed6 a, uint256 b, uint256 c) internal pure returns (UFixed6) {
+        return unsafeMuldivOut(a, UFixed6.wrap(b), UFixed6.wrap(c));
+    }
+
+    /**
+     * @notice Computes a * b / c without loss of precision due to BASE conversion
+     * @dev Does not revert on divide-by-0, instead returns `ONE` for `0/0` and `MAX` for `n/0`.
+     * @param a First unsigned fixed-decimal
+     * @param b Unsigned fixed-decimal to multiply by
+     * @param c Unsigned fixed-decimal to divide by
+     * @return Resulting computation
+     */
+    function unsafeMuldiv(UFixed6 a, UFixed6 b, UFixed6 c) internal pure returns (UFixed6) {
+        if (isZero(c)) {
+            return (isZero(a) || isZero(b)) ? ONE : MAX;
+        } else {
+            return muldiv(a, b, c);
+        }
+    }
+
+    /**
+     * @notice Computes a * b / c without loss of precision due to BASE conversion, rounding the result up to the next integer if there is a remainder
+     * @dev Does not revert on divide-by-0, instead returns `ONE` for `0/0` and `MAX` for `n/0`.
+     * @param a First unsigned fixed-decimal
+     * @param b Unsigned fixed-decimal to multiply by
+     * @param c Unsigned fixed-decimal to divide by
+     * @return Resulting computation
+     */
+    function unsafeMuldivOut(UFixed6 a, UFixed6 b, UFixed6 c) internal pure returns (UFixed6) {
+        if (isZero(c)) {
+            return (isZero(a) || isZero(b)) ? ONE : MAX;
+        } else {
+            return muldivOut(a, b, c);
+        }
     }
 
     /**

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "2.2.0-rc0",
+  "version": "2.2.0-rc1",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"

--- a/test/unit/number/UFixed18.test.ts
+++ b/test/unit/number/UFixed18.test.ts
@@ -303,6 +303,152 @@ describe('UFixed18', () => {
     })
   })
 
+  describe('#unsafeMuldiv', async () => {
+    it('muldivs', async () => {
+      expect(
+        await uFixed18.unsafeMuldiv1(utils.parseEther('20'), utils.parseEther('10'), utils.parseEther('2')),
+      ).to.equal(utils.parseEther('100'))
+    })
+
+    it('muldivs', async () => {
+      expect(await uFixed18.unsafeMuldiv2(utils.parseEther('20'), 10, 2)).to.equal(utils.parseEther('100'))
+    })
+
+    it('muldivs (precision)', async () => {
+      expect(
+        await uFixed18.unsafeMuldiv1(
+          utils.parseEther('1.111111111111111111'),
+          utils.parseEther('0.333333333333333333'),
+          utils.parseEther('0.333333333333333333'),
+        ),
+      ).to.equal(utils.parseEther('1.111111111111111111'))
+    })
+
+    it('muldivs (precision)', async () => {
+      expect(
+        await uFixed18.unsafeMuldiv2(
+          utils.parseEther('1.111111111111111111'),
+          utils.parseEther('0.333333333333333333'),
+          utils.parseEther('0.333333333333333333'),
+        ),
+      ).to.equal(utils.parseEther('1.111111111111111111'))
+    })
+
+    it('muldivs (rounds down)', async () => {
+      expect(await uFixed18.unsafeMuldiv1(1, 21, 10)).to.equal(2)
+      expect(await uFixed18.unsafeMuldiv2(1, 21, 10)).to.equal(2)
+    })
+
+    it('returns max for n/0', async () => {
+      expect(
+        await uFixed18.unsafeMuldiv1(utils.parseEther('20'), utils.parseEther('10'), utils.parseEther('0')),
+      ).to.equal(ethers.constants.MaxUint256)
+    })
+
+    it('returns max for n/0', async () => {
+      expect(
+        await uFixed18.unsafeMuldiv2(utils.parseEther('20'), utils.parseEther('10'), utils.parseEther('0')),
+      ).to.equal(ethers.constants.MaxUint256)
+    })
+
+    it('returns one for 0/0 (a)', async () => {
+      expect(
+        await uFixed18.unsafeMuldiv1(utils.parseEther('0'), utils.parseEther('10'), utils.parseEther('0')),
+      ).to.equal(utils.parseEther('1'))
+    })
+
+    it('returns one for 0/0 (a)', async () => {
+      expect(
+        await uFixed18.unsafeMuldiv2(utils.parseEther('0'), utils.parseEther('10'), utils.parseEther('0')),
+      ).to.equal(utils.parseEther('1'))
+    })
+
+    it('returns one for 0/0 (b)', async () => {
+      expect(
+        await uFixed18.unsafeMuldiv1(utils.parseEther('20'), utils.parseEther('0'), utils.parseEther('0')),
+      ).to.equal(utils.parseEther('1'))
+    })
+
+    it('returns one for 0/0 (b)', async () => {
+      expect(
+        await uFixed18.unsafeMuldiv2(utils.parseEther('20'), utils.parseEther('0'), utils.parseEther('0')),
+      ).to.equal(utils.parseEther('1'))
+    })
+  })
+
+  describe('#unsafeMuldivOut', async () => {
+    it('muldivs', async () => {
+      expect(
+        await uFixed18.unsafeMuldivOut1(utils.parseEther('20'), utils.parseEther('10'), utils.parseEther('2')),
+      ).to.equal(utils.parseEther('100'))
+    })
+
+    it('muldivs', async () => {
+      expect(await uFixed18.unsafeMuldivOut2(utils.parseEther('20'), 10, 2)).to.equal(utils.parseEther('100'))
+    })
+
+    it('muldivs (precision)', async () => {
+      expect(
+        await uFixed18.unsafeMuldivOut1(
+          utils.parseEther('1.111111111111111111'),
+          utils.parseEther('0.333333333333333333'),
+          utils.parseEther('0.333333333333333333'),
+        ),
+      ).to.equal(utils.parseEther('1.111111111111111111'))
+    })
+
+    it('muldivs (precision)', async () => {
+      expect(
+        await uFixed18.unsafeMuldivOut2(
+          utils.parseEther('1.111111111111111111'),
+          utils.parseEther('0.333333333333333333'),
+          utils.parseEther('0.333333333333333333'),
+        ),
+      ).to.equal(utils.parseEther('1.111111111111111111'))
+    })
+
+    it('muldivs (rounds up)', async () => {
+      expect(await uFixed18.unsafeMuldivOut1(1, 21, 10)).to.equal(3)
+      expect(await uFixed18.unsafeMuldivOut2(1, 21, 10)).to.equal(3)
+    })
+
+    it('returns max for n/0', async () => {
+      expect(
+        await uFixed18.unsafeMuldivOut1(utils.parseEther('20'), utils.parseEther('10'), utils.parseEther('0')),
+      ).to.equal(ethers.constants.MaxUint256)
+    })
+
+    it('returns max for n/0', async () => {
+      expect(
+        await uFixed18.unsafeMuldivOut2(utils.parseEther('20'), utils.parseEther('10'), utils.parseEther('0')),
+      ).to.equal(ethers.constants.MaxUint256)
+    })
+
+    it('returns one for 0/0 (a)', async () => {
+      expect(
+        await uFixed18.unsafeMuldivOut1(utils.parseEther('0'), utils.parseEther('10'), utils.parseEther('0')),
+      ).to.equal(utils.parseEther('1'))
+    })
+
+    it('returns one for 0/0 (a)', async () => {
+      expect(
+        await uFixed18.unsafeMuldivOut2(utils.parseEther('0'), utils.parseEther('10'), utils.parseEther('0')),
+      ).to.equal(utils.parseEther('1'))
+    })
+
+    it('returns one for 0/0 (b)', async () => {
+      expect(
+        await uFixed18.unsafeMuldivOut1(utils.parseEther('20'), utils.parseEther('0'), utils.parseEther('0')),
+      ).to.equal(utils.parseEther('1'))
+    })
+
+    it('returns one for 0/0 (b)', async () => {
+      expect(
+        await uFixed18.unsafeMuldivOut2(utils.parseEther('20'), utils.parseEther('0'), utils.parseEther('0')),
+      ).to.equal(utils.parseEther('1'))
+    })
+  })
+
   describe('#eq', async () => {
     it('returns true', async () => {
       expect(await uFixed18.eq(12, 12)).to.equal(true)

--- a/test/unit/number/UFixed6.test.ts
+++ b/test/unit/number/UFixed6.test.ts
@@ -328,6 +328,152 @@ describe('UFixed6', () => {
     })
   })
 
+  describe('#unsafeMuldiv', async () => {
+    it('muldivs', async () => {
+      expect(
+        await uFixed6.unsafeMuldiv1(utils.parseUnits('20', 6), utils.parseUnits('10', 6), utils.parseUnits('2', 6)),
+      ).to.equal(utils.parseUnits('100', 6))
+    })
+
+    it('muldivs', async () => {
+      expect(await uFixed6.unsafeMuldiv2(utils.parseUnits('20', 6), 10, 2)).to.equal(utils.parseUnits('100', 6))
+    })
+
+    it('muldivs (precision)', async () => {
+      expect(
+        await uFixed6.unsafeMuldiv1(
+          utils.parseUnits('1.111111', 6),
+          utils.parseUnits('0.333333', 6),
+          utils.parseUnits('0.333333', 6),
+        ),
+      ).to.equal(utils.parseUnits('1.111111', 6))
+    })
+
+    it('muldivs (precision)', async () => {
+      expect(
+        await uFixed6.unsafeMuldiv2(
+          utils.parseUnits('1.111111', 6),
+          utils.parseUnits('0.333333', 6),
+          utils.parseUnits('0.333333', 6),
+        ),
+      ).to.equal(utils.parseUnits('1.111111', 6))
+    })
+
+    it('muldivs (rounds down)', async () => {
+      expect(await uFixed6.unsafeMuldiv1(1, 21, 10)).to.equal(2)
+      expect(await uFixed6.unsafeMuldiv2(1, 21, 10)).to.equal(2)
+    })
+
+    it('returns max on n/0', async () => {
+      expect(
+        await uFixed6.unsafeMuldiv1(utils.parseUnits('20', 6), utils.parseUnits('10', 6), utils.parseUnits('0', 6)),
+      ).to.equal(ethers.constants.MaxUint256)
+    })
+
+    it('returns max on n/0', async () => {
+      expect(
+        await uFixed6.unsafeMuldiv2(utils.parseUnits('20', 6), utils.parseUnits('10', 6), utils.parseUnits('0', 6)),
+      ).to.equal(ethers.constants.MaxUint256)
+    })
+
+    it('returns one on 0/0 (a)', async () => {
+      expect(
+        await uFixed6.unsafeMuldiv1(utils.parseUnits('0', 6), utils.parseUnits('10', 6), utils.parseUnits('0', 6)),
+      ).to.equal(utils.parseUnits('1', 6))
+    })
+
+    it('returns one on 0/0 (a)', async () => {
+      expect(
+        await uFixed6.unsafeMuldiv2(utils.parseUnits('0', 6), utils.parseUnits('10', 6), utils.parseUnits('0', 6)),
+      ).to.equal(utils.parseUnits('1', 6))
+    })
+
+    it('returns one on 0/0 (b)', async () => {
+      expect(
+        await uFixed6.unsafeMuldiv1(utils.parseUnits('20', 6), utils.parseUnits('0', 6), utils.parseUnits('0', 6)),
+      ).to.equal(utils.parseUnits('1', 6))
+    })
+
+    it('returns one on 0/0 (b)', async () => {
+      expect(
+        await uFixed6.unsafeMuldiv2(utils.parseUnits('20', 6), utils.parseUnits('0', 6), utils.parseUnits('0', 6)),
+      ).to.equal(utils.parseUnits('1', 6))
+    })
+  })
+
+  describe('#unsafeMuldivOut', async () => {
+    it('muldivs', async () => {
+      expect(
+        await uFixed6.unsafeMuldivOut1(utils.parseUnits('20', 6), utils.parseUnits('10', 6), utils.parseUnits('2', 6)),
+      ).to.equal(utils.parseUnits('100', 6))
+    })
+
+    it('muldivs', async () => {
+      expect(await uFixed6.unsafeMuldivOut2(utils.parseUnits('20', 6), 10, 2)).to.equal(utils.parseUnits('100', 6))
+    })
+
+    it('muldivs (precision)', async () => {
+      expect(
+        await uFixed6.unsafeMuldivOut1(
+          utils.parseUnits('1.111111', 6),
+          utils.parseUnits('0.333333', 6),
+          utils.parseUnits('0.333333', 6),
+        ),
+      ).to.equal(utils.parseUnits('1.111111', 6))
+    })
+
+    it('muldivs (precision)', async () => {
+      expect(
+        await uFixed6.unsafeMuldivOut2(
+          utils.parseUnits('1.111111', 6),
+          utils.parseUnits('0.333333', 6),
+          utils.parseUnits('0.333333', 6),
+        ),
+      ).to.equal(utils.parseUnits('1.111111', 6))
+    })
+
+    it('muldivs (rounds up)', async () => {
+      expect(await uFixed6.unsafeMuldivOut1(1, 21, 10)).to.equal(3)
+      expect(await uFixed6.unsafeMuldivOut2(1, 21, 10)).to.equal(3)
+    })
+
+    it('returns max on n/0', async () => {
+      expect(
+        await uFixed6.unsafeMuldivOut1(utils.parseUnits('20', 6), utils.parseUnits('10', 6), utils.parseUnits('0', 6)),
+      ).to.equal(ethers.constants.MaxUint256)
+    })
+
+    it('returns max on n/0', async () => {
+      expect(
+        await uFixed6.unsafeMuldivOut2(utils.parseUnits('20', 6), utils.parseUnits('10', 6), utils.parseUnits('0', 6)),
+      ).to.equal(ethers.constants.MaxUint256)
+    })
+
+    it('returns one on 0/0 (a)', async () => {
+      expect(
+        await uFixed6.unsafeMuldivOut1(utils.parseUnits('0', 6), utils.parseUnits('10', 6), utils.parseUnits('0', 6)),
+      ).to.equal(utils.parseUnits('1', 6))
+    })
+
+    it('returns one on 0/0 (a)', async () => {
+      expect(
+        await uFixed6.unsafeMuldivOut2(utils.parseUnits('0', 6), utils.parseUnits('10', 6), utils.parseUnits('0', 6)),
+      ).to.equal(utils.parseUnits('1', 6))
+    })
+
+    it('returns one on 0/0 (b)', async () => {
+      expect(
+        await uFixed6.unsafeMuldivOut1(utils.parseUnits('20', 6), utils.parseUnits('0', 6), utils.parseUnits('0', 6)),
+      ).to.equal(utils.parseUnits('1', 6))
+    })
+
+    it('returns one on 0/0 (b)', async () => {
+      expect(
+        await uFixed6.unsafeMuldivOut2(utils.parseUnits('20', 6), utils.parseUnits('0', 6), utils.parseUnits('0', 6)),
+      ).to.equal(utils.parseUnits('1', 6))
+    })
+  })
+
   describe('#eq', async () => {
     it('returns true', async () => {
       expect(await uFixed6.eq(12, 12)).to.equal(true)


### PR DESCRIPTION
Adds `unsafeMuldiv / unsafeMuldivOut` functions for the `UFixed` type to complete the default-instead-of-revert functionality set.