### PR TITLE
Add Kept internal hook

### DIFF
--- a/contracts/attribute/Kept/Kept.sol
+++ b/contracts/attribute/Kept/Kept.sol
@@ -72,6 +72,9 @@ abstract contract Kept is IKept, Initializable {
     /// @notice Placed on a function to incentivize keepers to call it
     /// @param config The multiplier and buffer configuration to apply
     /// @param data Arbitrary data to pass to the _raiseKeeperFee function
+    /// @param applicableCalldata The applicable calldata
+    /// @param applicableValue The applicable value
+    /// @param data Arbitrary data to pass to the _raiseKeeperFee function
     modifier keep(
         KeepConfig memory config,
         bytes memory applicableCalldata,
@@ -84,10 +87,16 @@ abstract contract Kept is IKept, Initializable {
 
         uint256 applicableGas = startGas - gasleft();
 
-        _handleKeeperReward(config, applicableGas, applicableCalldata, applicableValue, data);
+        _handleKeeperFee(config, applicableGas, applicableCalldata, applicableValue, data);
     }
 
-    function _handleKeeperReward(
+    /// @notice Called by the keep modifier to handle keeper fee computation and payment
+    /// @param config The multiplier and buffer configuration to apply
+    /// @param applicableGas The applicable gas cost
+    /// @param applicableCalldata The applicable calldata
+    /// @param applicableValue The applicable value
+    /// @param data Arbitrary data to pass to the _raiseKeeperFee function
+    function _handleKeeperFee(
         KeepConfig memory config,
         uint256 applicableGas,
         bytes memory applicableCalldata,

--- a/contracts/attribute/Kept/Kept.sol
+++ b/contracts/attribute/Kept/Kept.sol
@@ -31,7 +31,8 @@ abstract contract Kept is IKept, Initializable {
     /// @notice Called by the keep modifier to raise the optionally raise the keeper fee
     /// @param amount The amount of keeper fee to raise
     /// @param data Arbitrary data passed in from the keep modifier
-    function _raiseKeeperFee(UFixed18 amount, bytes memory data) internal virtual { }
+    /// @return The amount of keeper fee that was actually raised
+    function _raiseKeeperFee(UFixed18 amount, bytes memory data) internal virtual returns (UFixed18) { return amount; }
 
     /// @notice Computes the calldata portion of the keeper fee
     /// @dev Used for L2 implementation with significant calldata costs
@@ -40,7 +41,7 @@ abstract contract Kept is IKept, Initializable {
     /// @param bufferCalldata The buffer to apply to the calldata cost
     /// @return The calldata portion of the keeper fee
     function _calldataFee(
-        bytes calldata applicableCalldata,
+        bytes memory applicableCalldata,
         UFixed18 multiplierCalldata,
         uint256 bufferCalldata
     ) internal view virtual returns (UFixed18) { return UFixed18Lib.ZERO; }
@@ -73,7 +74,7 @@ abstract contract Kept is IKept, Initializable {
     /// @param data Arbitrary data to pass to the _raiseKeeperFee function
     modifier keep(
         KeepConfig memory config,
-        bytes calldata applicableCalldata,
+        bytes memory applicableCalldata,
         uint256 applicableValue,
         bytes memory data
     ) {
@@ -82,13 +83,24 @@ abstract contract Kept is IKept, Initializable {
         _;
 
         uint256 applicableGas = startGas - gasleft();
+
+        _handleKeeperReward(config, applicableGas, applicableCalldata, applicableValue, data);
+    }
+
+    function _handleKeeperReward(
+        KeepConfig memory config,
+        uint256 applicableGas,
+        bytes memory applicableCalldata,
+        uint256 applicableValue,
+        bytes memory data
+    ) internal {
         (UFixed18 baseFee, UFixed18 calldataFee) = (
             _baseFee(applicableGas, config.multiplierBase, config.bufferBase),
             _calldataFee(applicableCalldata, config.multiplierCalldata, config.bufferCalldata)
         );
 
         UFixed18 keeperFee = UFixed18.wrap(applicableValue).add(baseFee).add(calldataFee).mul(_etherPrice());
-        _raiseKeeperFee(keeperFee, data);
+        keeperFee = _raiseKeeperFee(keeperFee, data);
         keeperToken().push(msg.sender, keeperFee);
 
         emit KeeperCall(msg.sender, applicableGas, applicableValue, baseFee, calldataFee, keeperFee);

--- a/contracts/attribute/Kept/Kept_Arbitrum.sol
+++ b/contracts/attribute/Kept/Kept_Arbitrum.sol
@@ -19,7 +19,7 @@ abstract contract Kept_Arbitrum is Kept {
     // Tx Fee = block.baseFee * l2GasUsed + ArbGasInfo.getL1BaseFeeEstimate() * 16 * (calldataLength + fixedOverhead)
     // Dynamic buffer = (ArbGasInfo.getL1BaseFeeEstimate() * 16 * (calldataLength + fixedOverhead))
     function _calldataFee(
-        bytes calldata applicableCalldata,
+        bytes memory applicableCalldata,
         UFixed18 multiplierCalldata,
         uint256 bufferCalldata
     ) internal view virtual override returns (UFixed18) {

--- a/contracts/attribute/Kept/Kept_Optimism.sol
+++ b/contracts/attribute/Kept/Kept_Optimism.sol
@@ -18,7 +18,7 @@ abstract contract Kept_Optimism is Kept {
     // https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee
     // Adds a buffer to the L1 gas used to account for the overhead of the transaction
     function _calldataFee(
-        bytes calldata applicableCalldata,
+        bytes memory applicableCalldata,
         UFixed18 multiplierCalldata,
         uint256 bufferCalldata
     ) internal view virtual override returns (UFixed18) {

--- a/contracts/mocks/MockKept.sol
+++ b/contracts/mocks/MockKept.sol
@@ -17,9 +17,10 @@ contract MockKept is Kept {
         super.__Kept__initialize(ethTokenOracleFeed_, keeperToken_);
     }
 
-    function _raiseKeeperFee(UFixed18 amount, bytes memory data) internal override {
+    function _raiseKeeperFee(UFixed18 amount, bytes memory data) internal override returns (UFixed18) {
         emit RaiseKeeperFeeCalled(amount, data);
         keeperToken().pull(benefactor, amount);
+        return amount;
     }
 
     function toBeKept(UFixed18 multiplier, uint256 buffer, uint256 value, bytes memory data)

--- a/contracts/mocks/MockKept_Arbitrum.sol
+++ b/contracts/mocks/MockKept_Arbitrum.sol
@@ -17,9 +17,10 @@ contract MockKept_Arbitrum is Kept_Arbitrum {
         super.__Kept__initialize(ethTokenOracleFeed_, keeperToken_);
     }
 
-    function _raiseKeeperFee(UFixed18 amount, bytes memory data) internal override {
+    function _raiseKeeperFee(UFixed18 amount, bytes memory data) internal override returns (UFixed18) {
         emit RaiseKeeperFeeCalled(amount, data);
         keeperToken().pull(benefactor, amount);
+        return amount;
     }
 
     function toBeKept(

--- a/contracts/mocks/MockKept_Optimism.sol
+++ b/contracts/mocks/MockKept_Optimism.sol
@@ -17,9 +17,10 @@ contract MockKept_Optimism is Kept_Optimism {
         super.__Kept__initialize(ethTokenOracleFeed_, keeperToken_);
     }
 
-    function _raiseKeeperFee(UFixed18 amount, bytes memory data) internal override {
+    function _raiseKeeperFee(UFixed18 amount, bytes memory data) internal override returns (UFixed18) {
         emit RaiseKeeperFeeCalled(amount, data);
         keeperToken().pull(benefactor, amount);
+        return amount;
     }
 
     function toBeKept(

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "2.2.0-rc2",
+  "version": "2.2.0-rc3",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "2.2.0-rc0",
+  "version": "2.2.0-rc2",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"


### PR DESCRIPTION
- Adds a `_handleKeeperFee` internal hook that can be used in place of the `keep` modifier if gas does not need to be measured.
- Moves `applicableData` from calldata -> memory to increase flexibility (at the expense of gas cost).
- Allows `_raiseKeeperFee` to raise less than is requested without revert.