### PR TITLE
Add ProxyOwner

### DIFF
--- a/contracts/access/ProxyOwner.sol
+++ b/contracts/access/ProxyOwner.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+/**
+ * @title ProxyOwner
+ * @notice ProxyAdmin with 2-step ownership transfer
+ * @dev Adds 2-step ownership transfer to the OpenZeppelin ProxyAdmin contract, both for the owner of the ProxyAdmin
+ *      and to the proxy ownership transfer.
+ */
+contract ProxyOwner is ProxyAdmin, Ownable2Step {
+    error ProxyOwnerNotPendingAdminError();
+
+    /// @dev Mapping of the pending admin for each proxy
+    mapping(TransparentUpgradeableProxy => address) public pendingAdmins;
+
+    /// @dev Only allows calls from the pending admin of `proxy`
+    modifier onlyPendingOwner(TransparentUpgradeableProxy proxy) {
+        if(pendingAdmins[proxy] != msg.sender) revert ProxyOwnerNotPendingAdminError();
+        _;
+    }
+    
+    /// @notice Sets the pending admin for `proxy` to `newAdmin`
+    /// @param proxy The proxy to change the pending admin for
+    /// @param newAdmin The address of the new pending admin
+    function changeProxyAdmin(TransparentUpgradeableProxy proxy, address newAdmin) public override onlyOwner {
+        pendingAdmins[proxy] = newAdmin;
+    }
+
+    /// @notice Processes the admin change for `proxy`
+    /// @dev Callback used by the new proxy owner
+    /// @param proxy The proxy to accept the pending admin for
+    function acceptProxyAdminCallback(TransparentUpgradeableProxy proxy) external onlyPendingOwner(proxy) {
+        proxy.changeAdmin(msg.sender);
+        delete pendingAdmins[proxy];
+    }
+
+    /// @notice Accepts ownership of `proxy`
+    /// @param previousOwner The previous owner of the proxy
+    /// @param proxy The proxy to accept ownership of
+    function acceptProxyAdmin(ProxyOwner previousOwner, TransparentUpgradeableProxy proxy) external onlyOwner {
+        previousOwner.acceptProxyAdminCallback(proxy);
+    }
+
+    function transferOwnership(address newOwner) public override(Ownable, Ownable2Step) {
+        super.transferOwnership(newOwner);
+    }
+
+    function _transferOwnership(address newOwner) internal override(Ownable, Ownable2Step) {
+        super._transferOwnership(newOwner);
+    }
+}

--- a/test/unit/access/ProxyOwner.test.ts
+++ b/test/unit/access/ProxyOwner.test.ts
@@ -1,0 +1,98 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import HRE from 'hardhat'
+
+import {
+  ProxyOwner,
+  ProxyOwner__factory,
+  ProxyAdmin__factory,
+  ProxyAdmin,
+  TransparentUpgradeableProxy,
+  TransparentUpgradeableProxy__factory,
+  ERC20,
+  ERC20__factory,
+} from '../../../types/generated'
+import exp from 'constants'
+
+const { ethers } = HRE
+
+const SLOT = ethers.utils.keccak256(Buffer.from('equilibria.root.Proxyowner.testSlot'))
+
+describe('ProxyOwner', () => {
+  let owner: SignerWithAddress
+  let owner2: SignerWithAddress
+  let user: SignerWithAddress
+  let proxyOwner: ProxyOwner
+  let proxyOwner2: ProxyOwner
+  let proxyAdmin: ProxyAdmin
+  let proxy: TransparentUpgradeableProxy
+  let impl: ERC20
+  let impl2: ERC20
+
+  beforeEach(async () => {
+    ;[owner, owner2, user] = await ethers.getSigners()
+    impl = await new ERC20__factory(owner).deploy('Test', 'TEST')
+    impl2 = await new ERC20__factory(owner).deploy('Test', 'TEST')
+    proxyOwner = await new ProxyOwner__factory(owner).deploy()
+    proxyOwner2 = await new ProxyOwner__factory(owner).deploy()
+    proxyAdmin = await new ProxyAdmin__factory(owner).deploy()
+    proxy = await new TransparentUpgradeableProxy__factory(owner).deploy(impl.address, proxyAdmin.address, '0x')
+  })
+
+  describe('proxyAdmin -> proxyOwner', async () => {
+    it('transfers ownership', async () => {
+      await proxyAdmin.connect(owner).changeProxyAdmin(proxy.address, proxyOwner.address)
+      expect(await proxyOwner.getProxyAdmin(proxy.address)).to.equal(proxyOwner.address)
+    })
+  })
+
+  describe('proxyOwner -> proxyOwner', async () => {
+    beforeEach(async () => {
+      await proxyAdmin.connect(owner).changeProxyAdmin(proxy.address, proxyOwner.address)
+    })
+
+    it('transfers ownership', async () => {
+      await proxyOwner.connect(owner).transferOwnership(owner2.address)
+      expect(await proxyOwner.owner()).to.equal(owner.address)
+      expect(await proxyOwner.pendingOwner()).to.equal(owner2.address)
+
+      await proxyOwner.connect(owner2).acceptOwnership()
+      expect(await proxyOwner.owner()).to.equal(owner2.address)
+      expect(await proxyOwner.pendingOwner()).to.equal(ethers.constants.AddressZero)
+    })
+
+    it('transfers ownership of proxy', async () => {
+      await proxyOwner.connect(owner).changeProxyAdmin(proxy.address, proxyOwner2.address)
+      expect(await proxyOwner.getProxyAdmin(proxy.address)).to.equal(proxyOwner.address)
+      expect(await proxyOwner.pendingAdmins(proxy.address)).to.equal(proxyOwner2.address)
+
+      await proxyOwner2.connect(owner).acceptProxyAdmin(proxyOwner.address, proxy.address)
+      expect(await proxyOwner2.getProxyAdmin(proxy.address)).to.equal(proxyOwner2.address)
+      expect(await proxyOwner.pendingAdmins(proxy.address)).to.equal(ethers.constants.AddressZero)
+    })
+
+    it('reverts if not owner (change)', async () => {
+      await expect(proxyOwner.connect(user).changeProxyAdmin(proxy.address, proxyOwner2.address)).to.be.revertedWith(
+        'Ownable: caller is not the owner',
+      )
+    })
+
+    it('reverts if not owner (accept)', async () => {
+      await expect(proxyOwner.connect(user).acceptProxyAdmin(proxyOwner2.address, proxy.address)).to.be.revertedWith(
+        'Ownable: caller is not the owner',
+      )
+    })
+
+    it('reverts if not pending', async () => {
+      await expect(proxyOwner2.connect(owner).acceptProxyAdmin(proxyOwner2.address, proxy.address)).to.be.revertedWith(
+        'ProxyOwnerNotPendingAdminError',
+      )
+    })
+
+    it('reverts if not pending (callback)', async () => {
+      await expect(proxyOwner2.connect(owner).acceptProxyAdminCallback(proxy.address)).to.be.revertedWith(
+        'ProxyOwnerNotPendingAdminError',
+      )
+    })
+  })
+})


### PR DESCRIPTION
# ProxyOwner
Adds two-step flows for all ownership transfers

### Owner
Uses `Ownable2Step` to create process:
  1. `owner -> .transferOwnership(newOwner)`
  2. `newOwner -> .acceptOwnership()`

### Proxy Owner
Overrides / Adds methods to create process:
  1. `proxyOwner.owner -> proxyOwner.changeProxyAdmin(newProxyOwner)`
  2. `newProxyOwner.owner -> newProxyOwner.acceptProxyAdmin(proxyOwner, newProxyOwner)`