### PR TITLE
Add signer field to Common in Verifier

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "2.3.0-rc0",
+  "version": "2.3.0-rc1",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "2.3.0-rc1",
+  "version": "2.3.0-rc2",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"

--- a/contracts/verifier/interfaces/IVerifierBase.sol
+++ b/contracts/verifier/interfaces/IVerifierBase.sol
@@ -31,17 +31,17 @@ interface IVerifierBase {
 
     /// @notice Verifies the signature of no-op common message
     /// @dev Cancels the nonce after verifying the signature
+    ///      Reverts if the signature does not match the signer
     /// @param common The common data of the message
     /// @param signature The signature of the account for the message
-    /// @return The address corresponding to the signature
-    function verifyCommon(Common calldata common, bytes calldata signature) external returns (address);
 
+    function verifyCommon(Common calldata common, bytes calldata signature) external;
     /// @notice Verifies the signature of a group cancellation type
     /// @dev Cancels the nonce after verifying the signature
+    ///      Reverts if the signature does not match the signer
     /// @param groupCancellation The group cancellation to verify
     /// @param signature The signature of the account for the group cancellation
-    /// @return The address corresponding to the signature    
-    function verifyGroupCancellation(GroupCancellation calldata groupCancellation, bytes calldata signature) external returns (address);
+    function verifyGroupCancellation(GroupCancellation calldata groupCancellation, bytes calldata signature) external;
 
     /// @notice Cancels a nonce
     /// @param nonce The nonce to cancel

--- a/contracts/verifier/types/Common.sol
+++ b/contracts/verifier/types/Common.sol
@@ -3,15 +3,17 @@ pragma solidity ^0.8.13;
 
 /// @notice Fields which need to be hashed in any EIP712 action
 struct Common {
-    /// EOA signing the message
+    /// @dev The target account of the message (usually the account on behalf of which the action is being performed)
     address account;
-    /// ensures the message is unique to a particular protocol version, chain, and verifier
+    /// @dev EOA signing the message (usually either the account or a delegate of the account)
+    address signer;
+    /// @dev ensures the message is unique to a particular protocol version, chain, and verifier
     address domain;
-    /// per-sender nonce which is automatically cancelled upon validation
+    /// @dev per-sender nonce which is automatically cancelled upon validation
     uint256 nonce;
-    /// per-sender nonce which must be manually cancelled with a GroupCancellation message
+    /// @dev per-sender nonce which must be manually cancelled with a GroupCancellation message
     uint256 group;
-    /// prevents this message from having the intended effect after a specified timestamp
+    /// @dev prevents this message from having the intended effect after a specified timestamp
     uint256 expiry;
 }
 using CommonLib for Common global;
@@ -21,10 +23,10 @@ using CommonLib for Common global;
 library CommonLib {
     /// @dev used to verify a signed message
     bytes32 constant public STRUCT_HASH =
-        keccak256("Common(address account,address domain,uint256 nonce,uint256 group,uint256 expiry)");
+        keccak256("Common(address account,address signer,address domain,uint256 nonce,uint256 group,uint256 expiry)");
 
     /// @dev used to create a signed message
     function hash(Common memory self) internal pure returns (bytes32) {
-        return keccak256(abi.encode(STRUCT_HASH, self.account, self.domain, self.nonce, self.group, self.expiry));
+        return keccak256(abi.encode(STRUCT_HASH, self.account, self.signer, self.domain, self.nonce, self.group, self.expiry));
     }
 }

--- a/contracts/verifier/types/GroupCancellation.sol
+++ b/contracts/verifier/types/GroupCancellation.sol
@@ -17,7 +17,8 @@ using GroupCancellationLib for GroupCancellation global;
 library GroupCancellationLib {
     bytes32 constant public STRUCT_HASH = keccak256(
         "GroupCancellation(uint256 group,Common common)"
-        "Common(address account,address domain,uint256 nonce,uint256 group,uint256 expiry)");
+        "Common(address account,address signer,address domain,uint256 nonce,uint256 group,uint256 expiry)"
+    );
 
     function hash(GroupCancellation memory self) internal pure returns (bytes32) {
         return keccak256(abi.encode(STRUCT_HASH, self.group, CommonLib.hash(self.common)));

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -126,6 +126,7 @@ const config: HardhatUserConfig = {
   },
   dependencyCompiler: {
     paths: [
+      '@openzeppelin/contracts/interfaces/IERC1271.sol',
       '@openzeppelin/contracts/vendor/optimism/ICrossDomainMessenger.sol',
       '@openzeppelin/contracts/vendor/arbitrum/IArbSys.sol',
       '@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "2.3.0-rc0",
+  "version": "2.3.0-rc2",
   "scripts": {
     "build": "yarn compile",
     "compile": "hardhat compile",

--- a/test/testutil/erc712.ts
+++ b/test/testutil/erc712.ts
@@ -28,6 +28,7 @@ export async function signCommon(
   const types = {
     Common: [
       { name: 'account', type: 'address' },
+      { name: 'signer', type: 'address' },
       { name: 'domain', type: 'address' },
       { name: 'nonce', type: 'uint256' },
       { name: 'group', type: 'uint256' },
@@ -46,6 +47,7 @@ export async function signGroupCancellation(
   const types = {
     Common: [
       { name: 'account', type: 'address' },
+      { name: 'signer', type: 'address' },
       { name: 'domain', type: 'address' },
       { name: 'nonce', type: 'uint256' },
       { name: 'group', type: 'uint256' },


### PR DESCRIPTION
- Adds `signer` field to `Common` message type
- Adds support for `EIP1271` signatures w/ `Common` / `GroupCancellation` message types

Required to support `EIP1271` signature checking since we need to know the signer at time of check.