### PR TITLE
Extend factory to support create2

### DIFF
--- a/contracts/attribute/Factory.sol
+++ b/contracts/attribute/Factory.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-// TODO: should update all these to specific imports?
 import "@openzeppelin/contracts/utils/Create2.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import "./interfaces/IFactory.sol";

--- a/contracts/attribute/Factory.sol
+++ b/contracts/attribute/Factory.sol
@@ -44,7 +44,7 @@ abstract contract Factory is IFactory, Ownable, Pausable {
     /// @notice Creates a new instance at a deterministic address
     /// @dev Deploys a BeaconProxy with the this contract as the beacon
     /// @param data The initialization data
-    /// @param salt Used to determine a unique BeaconProxy address
+    /// @param salt Used along with initialization data to determine a unique BeaconProxy address
     /// @return newInstance The new instance
     function _create2(bytes memory data, bytes32 salt) internal returns (IInstance newInstance) {
         newInstance = IInstance(address(new BeaconProxy{salt: salt}(address(this), data)));
@@ -54,7 +54,7 @@ abstract contract Factory is IFactory, Ownable, Pausable {
     // @notice Calculates the address at which the instance will be deployed
     // @dev Passes the proxy's creation code along with this factory's address
     // @param data The same initialization data used in the _create2 call
-    // @param salt Used to determine a unique BeaconProxy address
+    // @param salt Used along with initialization data to determine a unique BeaconProxy address
     function _computeCreate2Address(bytes memory data, bytes32 salt) internal view returns (address) {
         bytes memory bytecode = abi.encodePacked(
             type(BeaconProxy).creationCode,

--- a/contracts/attribute/Factory.sol
+++ b/contracts/attribute/Factory.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+// TODO: should update all these to specific imports?
+import "@openzeppelin/contracts/utils/Create2.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import "./interfaces/IFactory.sol";
 import "./interfaces/IInstance.sol";
@@ -38,6 +40,15 @@ abstract contract Factory is IFactory, Ownable, Pausable {
     /// @return newInstance The new instance
     function _create(bytes memory data) internal returns (IInstance newInstance) {
         newInstance = IInstance(address(new BeaconProxy(address(this), data)));
+        _register(newInstance);
+    }
+    /// @notice Creates a new instance at a deterministic address
+    /// @dev Deploys a BeaconProxy with the this contract as the beacon
+    /// @param data The initialization data
+    /// @param salt Used to determine the address of the BeaconProxy
+    /// @return newInstance The new instance
+    function _create2(bytes memory data, bytes32 salt) internal returns (IInstance newInstance) {
+        newInstance = IInstance(address(new BeaconProxy{salt: salt}(address(this), data)));
         _register(newInstance);
     }
 

--- a/contracts/mocks/MockFactory.sol
+++ b/contracts/mocks/MockFactory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+// import "@openzeppelin/contracts/utils/Create2.sol";
 import "../attribute/Factory.sol";
 import "./MockInstance.sol";
 
@@ -11,12 +12,23 @@ contract MockFactory is Factory {
         __Factory__initialize();
     }
 
-    function create(string calldata name) external onlyOwner returns (MockInstance){
+    function create(string calldata name) external onlyOwner returns (MockInstance) {
         return MockInstance(address(_create(abi.encodeCall(MockInstance.initialize, (name)))));
     }
 
-    function create2(string calldata name, bytes32 salt) external onlyOwner returns (MockInstance){
+    function create2(string calldata name, bytes32 salt) external onlyOwner returns (MockInstance) {
         return MockInstance(address(_create2(abi.encodeCall(MockInstance.initialize, (name)), salt)));
+    }
+
+    function computeCreate2Address(string calldata name, bytes32 salt) external view returns (address) {
+        return _computeCreate2Address(abi.encodeCall(MockInstance.initialize, (name)), salt);
+        // TODO: this works; move implementation to Factory
+        /*return address(uint160(uint256(keccak256(abi.encodePacked(
+            bytes1(0xff),
+            address(this),
+            salt,
+            keccak256(abi.encodePacked(type(BeaconProxy).creationCode, abi.encode(address(this), abi.encodeCall(MockInstance.initialize, (name)))))
+        )))));*/
     }
 
     function onlyCallableByInstance() external view onlyInstance {}

--- a/contracts/mocks/MockFactory.sol
+++ b/contracts/mocks/MockFactory.sol
@@ -15,5 +15,9 @@ contract MockFactory is Factory {
         return MockInstance(address(_create(abi.encodeCall(MockInstance.initialize, (name)))));
     }
 
+    function create2(string calldata name, bytes32 salt) external onlyOwner returns (MockInstance){
+        return MockInstance(address(_create2(abi.encodeCall(MockInstance.initialize, (name)), salt)));
+    }
+
     function onlyCallableByInstance() external view onlyInstance {}
 }

--- a/contracts/mocks/MockFactory.sol
+++ b/contracts/mocks/MockFactory.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-// import "@openzeppelin/contracts/utils/Create2.sol";
 import "../attribute/Factory.sol";
 import "./MockInstance.sol";
 
@@ -22,13 +21,6 @@ contract MockFactory is Factory {
 
     function computeCreate2Address(string calldata name, bytes32 salt) external view returns (address) {
         return _computeCreate2Address(abi.encodeCall(MockInstance.initialize, (name)), salt);
-        // TODO: this works; move implementation to Factory
-        /*return address(uint160(uint256(keccak256(abi.encodePacked(
-            bytes1(0xff),
-            address(this),
-            salt,
-            keccak256(abi.encodePacked(type(BeaconProxy).creationCode, abi.encode(address(this), abi.encodeCall(MockInstance.initialize, (name)))))
-        )))));*/
     }
 
     function onlyCallableByInstance() external view onlyInstance {}

--- a/test/unit/attribute/Factory.test.ts
+++ b/test/unit/attribute/Factory.test.ts
@@ -58,6 +58,14 @@ describe('Factory', () => {
       const instance2Address = await factory.connect(owner).callStatic.create2('instance', salt2)
       expect(instance1Address).to.not.equal(instance2Address)
     })
+
+    it('can deterministically calculate address', async () => {
+      const instanceName = 'instance3'
+      const instanceSalt = ethers.utils.formatBytes32String('salt3')
+      const calculatedAddress = await factory.computeCreate2Address(instanceName, instanceSalt)
+      const actualAddress = await factory.connect(owner).callStatic.create2(instanceName, instanceSalt)
+      expect(calculatedAddress).to.equal(actualAddress)
+    })
   })
 
   describe('#instances', async () => {


### PR DESCRIPTION
Planning to use this in collateral accounts to deploy _BeaconProxies_ for `Account`, with `Controller` as the beacon.