### PR TITLE
Add GasOracle

### DIFF
--- a/contracts/attribute/Kept/Kept_Arbitrum.sol
+++ b/contracts/attribute/Kept/Kept_Arbitrum.sol
@@ -2,12 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "./Kept.sol";
-
-// https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L93
-interface ArbGasInfo {
-    /// @notice Get ArbOS's estimate of the L1 basefee in wei
-    function getL1BaseFeeEstimate() external view returns (uint256);
-}
+import { ArbGasInfo } from "../../gas/GasOracle_Arbitrum.sol";
 
 /// @dev Arbitrum Kept implementation
 abstract contract Kept_Arbitrum is Kept {

--- a/contracts/attribute/Kept/Kept_Optimism.sol
+++ b/contracts/attribute/Kept/Kept_Optimism.sol
@@ -2,15 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "./Kept.sol";
-
-interface OptGasInfo {
-    function getL1GasUsed(bytes memory) external view returns (uint256);
-    function l1BaseFee() external view returns (uint256);
-    function baseFeeScalar() external view returns (uint256);
-    function blobBaseFee() external view returns (uint256);
-    function blobBaseFeeScalar() external view returns (uint256);
-    function decimals() external view returns (uint256);
-}
+import { OptGasInfo } from "../../gas/GasOracle_Optimism.sol";
 
 /// @dev Optimism Kept implementation
 abstract contract Kept_Optimism is Kept {

--- a/contracts/gas/GasOracle.sol
+++ b/contracts/gas/GasOracle.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import { UFixed18, UFixed18Lib } from "../number/types/UFixed18.sol";
+import { Fixed18Lib } from "../number/types/Fixed18.sol";
+import { IGasOracle } from "./interfaces/IGasOracle.sol";
+
+/// @title GasOracle
+/// @notice Standalone gas oracle for externally computing keeper rewards based on ether gas costs
+contract GasOracle is IGasOracle {
+    /// @notice The total compute gas rewarded
+    UFixed18 public immutable COMPUTE_GAS;
+
+    /// @notice The total calldata gas rewarded
+    UFixed18 public immutable CALLDATA_GAS;
+
+    /// @notice Chainlink ETH-Token feed, where cost is expressed in terms of Token
+    AggregatorV3Interface public immutable FEED;
+
+    /// @notice The precomputed offset of the Chainlink feed (10 ^ decimals)
+    int256 public immutable FEED_OFFSET;
+
+    constructor(
+        AggregatorV3Interface feed,
+        uint256 decimals,
+        uint256 computeGas,
+        UFixed18 computeMultiplier,
+        uint256 computeBase,
+        uint256 calldataGas,
+        UFixed18 calldataMultiplier,
+        uint256 calldataBase
+    ) {
+        FEED = feed;
+        FEED_OFFSET = int256(10 ** decimals);
+        COMPUTE_GAS = _precompute(computeGas, computeMultiplier, computeBase);
+        CALLDATA_GAS = _precompute(calldataGas, calldataMultiplier, calldataBase);
+    }
+
+   /// @inheritdoc IGasOracle
+    function cost(uint256 value) external view returns (UFixed18) {
+        (UFixed18 baseFee, UFixed18 calldataFee) =
+            (UFixed18.wrap(block.basefee).mul(COMPUTE_GAS), UFixed18.wrap(_calldataBaseFee()).mul(CALLDATA_GAS));
+
+        return UFixed18.wrap(value).add(baseFee).add(calldataFee).mul(_etherPrice());
+    }
+
+    /// @notice Precomputes the total rewarded gas cost
+    /// @param gas The applicable gas cost
+    /// @param multiplier The reward multiplier to apply to the gas cost
+    /// @param base The base gas reward to add on to the gas cost
+    /// @return The total rewarded gas cost
+    function _precompute(uint256 gas, UFixed18 multiplier, uint256 base) private pure returns (UFixed18) {
+        return UFixed18Lib.from(gas).mul(multiplier).add(UFixed18Lib.from(base));
+    }
+
+    /// @notice Returns the price of ether in terms of the underlying token
+    /// @return The price of ether in terms of the underlyingtoken
+    function _etherPrice() private view returns (UFixed18) {
+        (, int256 answer, , ,) = FEED.latestRoundData();
+        return UFixed18Lib.from(Fixed18Lib.ratio(answer, FEED_OFFSET));
+    }
+
+    /// @notice Returns the base fee of the calldata
+    /// @dev Can be overridden to provide a non-zero calldata base fee for L2 implementations
+    /// @return The base fee of the calldata
+    function _calldataBaseFee() internal virtual view returns (uint256) { return 0; }
+}

--- a/contracts/gas/GasOracle_Arbitrum.sol
+++ b/contracts/gas/GasOracle_Arbitrum.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import { UFixed18, UFixed18Lib } from "../number/types/UFixed18.sol";
+import { Fixed18Lib } from "../number/types/Fixed18.sol";
+import { GasOracle } from "./GasOracle.sol";
+
+// https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L93
+interface ArbGasInfo {
+    /// @notice Get ArbOS's estimate of the L1 basefee in wei
+    function getL1BaseFeeEstimate() external view returns (uint256);
+}
+
+contract GasOracle_Arbitrum is GasOracle {
+    ArbGasInfo constant ARB_GAS = ArbGasInfo(0x000000000000000000000000000000000000006C);
+
+    constructor(
+        AggregatorV3Interface feed,
+        uint256 decimals,
+        uint256 computeGas,
+        UFixed18 computeMultiplier,
+        uint256 computeBase,
+        uint256 calldataGas,
+        UFixed18 calldataMultiplier,
+        uint256 calldataBase
+    ) GasOracle(feed, decimals, computeGas, computeMultiplier, computeBase, calldataGas, calldataMultiplier, calldataBase) { }
+
+    function _calldataBaseFee() internal override view returns (uint256) { return ARB_GAS.getL1BaseFeeEstimate(); }
+}

--- a/contracts/gas/GasOracle_Optimism.sol
+++ b/contracts/gas/GasOracle_Optimism.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import { UFixed18, UFixed18Lib } from "../number/types/UFixed18.sol";
+import { Fixed18Lib } from "../number/types/Fixed18.sol";
+import { GasOracle } from "./GasOracle.sol";
+
+interface OptGasInfo {
+    function getL1GasUsed(bytes memory) external view returns (uint256);
+    function l1BaseFee() external view returns (uint256);
+    function baseFeeScalar() external view returns (uint256);
+    function blobBaseFee() external view returns (uint256);
+    function blobBaseFeeScalar() external view returns (uint256);
+    function decimals() external view returns (uint256);
+}
+
+contract GasOracle_Optimism is GasOracle {
+    OptGasInfo constant OPT_GAS = OptGasInfo(0x420000000000000000000000000000000000000F);
+    uint256 public constant OPT_BASE_FEE_MULTIPLIER = 16;
+
+    constructor(
+        AggregatorV3Interface feed,
+        uint256 decimals,
+        uint256 computeGas,
+        UFixed18 computeMultiplier,
+        uint256 computeBase,
+        uint256 calldataGas,
+        UFixed18 calldataMultiplier,
+        uint256 calldataBase
+    ) GasOracle(feed, decimals, computeGas, computeMultiplier, computeBase, calldataGas, calldataMultiplier, calldataBase) { }
+
+    // https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/GasPriceOracle.sol#L138
+    // applicable to only the ecotone hardfork
+    function _calldataBaseFee() internal override view returns (uint256) {
+        return (
+            OPT_BASE_FEE_MULTIPLIER * OPT_GAS.baseFeeScalar() * OPT_GAS.l1BaseFee() +
+            OPT_GAS.blobBaseFeeScalar() * OPT_GAS.blobBaseFee()
+        ) / (OPT_BASE_FEE_MULTIPLIER * 10 ** OPT_GAS.decimals());
+    }
+}

--- a/contracts/gas/interfaces/IGasOracle.sol
+++ b/contracts/gas/interfaces/IGasOracle.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import { UFixed18 } from "../../number/types/UFixed18.sol";
+
+interface IGasOracle {
+    function COMPUTE_GAS() external view returns (UFixed18);
+    function CALLDATA_GAS() external view returns (UFixed18);
+    function FEED() external view returns (AggregatorV3Interface);
+    function FEED_OFFSET() external view returns (int256);
+
+    /// @notice Computes the reward of a transaction
+    /// @param value The ether value of the transaction in addition to the gas cost rewarded
+    /// @return The reward of the transaction
+    function cost(uint256 value) external view returns (UFixed18);
+}

--- a/contracts/mocks/GasOracleRunner.sol
+++ b/contracts/mocks/GasOracleRunner.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "../gas/GasOracle.sol";
+
+contract GasOracleRunner {
+    IGasOracle public gasOracle;
+
+    /// @dev Return result via event so that we can call `cost` without callstatic
+    event Cost(UFixed18 cost);
+
+    constructor(IGasOracle gasOracle_) {
+        gasOracle = gasOracle_;
+    }
+
+    /// @dev Non-view wrapper around `cost`, so that tests will use a non-zero base fee
+    function cost(uint256 value) external {
+        emit Cost(gasOracle.cost(value));
+    }
+}

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "2.3.0-rc4",
+  "version": "2.3.0-rc6",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "2.3.0-rc4",
+  "version": "2.3.0-rc6",
   "scripts": {
     "build": "yarn compile",
     "compile": "hardhat compile",

--- a/test/unit/gas/GasOracle.test.ts
+++ b/test/unit/gas/GasOracle.test.ts
@@ -1,0 +1,92 @@
+import { smock, FakeContract } from '@defi-wonderland/smock'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import HRE from 'hardhat'
+
+import { AggregatorV3Interface, GasOracle__factory, GasOracleRunner__factory } from '../../../types/generated'
+import { BigNumber } from 'ethers'
+
+const { ethers } = HRE
+
+describe('GasOracle', () => {
+  let owner: SignerWithAddress
+  let keeper: SignerWithAddress
+  let ethTokenOracleFeed: FakeContract<AggregatorV3Interface>
+
+  async function setBaseFee(baseFee: BigNumber) {
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', [baseFee.toHexString()])
+    await ethers.provider.send('evm_mine', [])
+  }
+
+  beforeEach(async () => {
+    ;[owner, keeper] = await ethers.getSigners()
+
+    ethTokenOracleFeed = await smock.fake<AggregatorV3Interface>('AggregatorV3Interface')
+
+    // Set baseFee to 0 to fix sc-coverage issue
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x0'])
+  })
+
+  after(async () => {
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x1'])
+  })
+
+  describe('#cost', async () => {
+    it('returns correct cost (no value)', async () => {
+      const gasOracle = await new GasOracle__factory(owner).deploy(
+        ethTokenOracleFeed.address,
+        8,
+        1_000_000,
+        ethers.utils.parseEther('1.1'),
+        200_000,
+        0,
+        0,
+        0,
+      )
+      const gasOracleRunner = await new GasOracleRunner__factory(owner).deploy(gasOracle.address)
+
+      // set eth price
+      ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
+
+      // set base fee
+      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+
+      // total gas cost = (1_000_000 * 1.1 + 200_000) = 1_300_000
+      // total eth cost = 1_300_000 * 1 gwei = 1.3 * 10^15 = 0.0013 eth
+      // total usd cost = 0.0025 * 1000 = 1.3 usd
+      expect(await gasOracleRunner.cost(0))
+        .to.emit(gasOracleRunner, 'Cost')
+        .withArgs(ethers.utils.parseEther('1.3'))
+    })
+
+    it('returns correct cost (value)', async () => {
+      const gasOracle = await new GasOracle__factory(owner).deploy(
+        ethTokenOracleFeed.address,
+        8,
+        1_000_000,
+        ethers.utils.parseEther('1.1'),
+        200_000,
+        0,
+        0,
+        0,
+      )
+      const gasOracleRunner = await new GasOracleRunner__factory(owner).deploy(gasOracle.address)
+
+      // set eth price
+      ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
+
+      // set base fee
+      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+
+      // set value
+      const value = ethers.utils.parseEther('0.0012') // 0.0012 eth
+
+      // total gas cost = (1_000_000 * 1.1 + 200_000) = 1_300_000
+      // total eth cost = 1_300_000 * 1 gwei + 0.0012 eth = 1.3 * 10^15 + 0.0012 eth = 0.0025 eth
+      // total usd cost = 0.0025 * 1000 = 2.5 usd
+      expect(await gasOracleRunner.cost(value))
+        .to.emit(gasOracleRunner, 'Cost')
+        .withArgs(ethers.utils.parseEther('2.5'))
+    })
+  })
+})

--- a/test/unit/gas/GasOracle.test.ts
+++ b/test/unit/gas/GasOracle.test.ts
@@ -49,12 +49,13 @@ describe('GasOracle', () => {
       ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
 
       // set base fee
-      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+      const baseFee = ethers.utils.parseUnits('1', 9)
+      await setBaseFee(baseFee) // 1 gwei
 
       // total gas cost = (1_000_000 * 1.1 + 200_000) = 1_300_000
       // total eth cost = 1_300_000 * 1 gwei = 1.3 * 10^15 = 0.0013 eth
       // total usd cost = 0.0025 * 1000 = 1.3 usd
-      expect(await gasOracleRunner.cost(0))
+      expect(await gasOracleRunner.cost(0, { gasPrice: baseFee }))
         .to.emit(gasOracleRunner, 'Cost')
         .withArgs(ethers.utils.parseEther('1.3'))
     })
@@ -76,7 +77,8 @@ describe('GasOracle', () => {
       ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
 
       // set base fee
-      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+      const baseFee = ethers.utils.parseUnits('1', 9)
+      await setBaseFee(baseFee) // 1 gwei
 
       // set value
       const value = ethers.utils.parseEther('0.0012') // 0.0012 eth
@@ -84,7 +86,7 @@ describe('GasOracle', () => {
       // total gas cost = (1_000_000 * 1.1 + 200_000) = 1_300_000
       // total eth cost = 1_300_000 * 1 gwei + 0.0012 eth = 1.3 * 10^15 + 0.0012 eth = 0.0025 eth
       // total usd cost = 0.0025 * 1000 = 2.5 usd
-      expect(await gasOracleRunner.cost(value))
+      expect(await gasOracleRunner.cost(value, { gasPrice: baseFee }))
         .to.emit(gasOracleRunner, 'Cost')
         .withArgs(ethers.utils.parseEther('2.5'))
     })

--- a/test/unit/gas/GasOracle_Arbitrum.test.ts
+++ b/test/unit/gas/GasOracle_Arbitrum.test.ts
@@ -1,0 +1,109 @@
+import { smock, FakeContract } from '@defi-wonderland/smock'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import HRE from 'hardhat'
+
+import {
+  AggregatorV3Interface,
+  GasOracle__factory,
+  GasOracleRunner__factory,
+  ArbGasInfo,
+} from '../../../types/generated'
+import { BigNumber } from 'ethers'
+
+const { ethers } = HRE
+
+describe('GasOracle_Arbitrum', () => {
+  let owner: SignerWithAddress
+  let keeper: SignerWithAddress
+  let ethTokenOracleFeed: FakeContract<AggregatorV3Interface>
+  let arbGas: FakeContract<ArbGasInfo>
+
+  async function setBaseFee(baseFee: BigNumber) {
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', [baseFee.toHexString()])
+    await ethers.provider.send('evm_mine', [])
+  }
+
+  beforeEach(async () => {
+    ;[owner, keeper] = await ethers.getSigners()
+
+    ethTokenOracleFeed = await smock.fake<AggregatorV3Interface>('AggregatorV3Interface')
+
+    arbGas = await smock.fake<ArbGasInfo>('ArbGasInfo', {
+      address: '0x000000000000000000000000000000000000006C',
+    })
+
+    // Set baseFee to 0 to fix sc-coverage issue
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x0'])
+  })
+
+  after(async () => {
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x1'])
+  })
+
+  describe('#cost', async () => {
+    it('returns correct cost (no value)', async () => {
+      const gasOracle = await new GasOracle__factory(owner).deploy(
+        ethTokenOracleFeed.address,
+        8,
+        1_000_000,
+        ethers.utils.parseEther('1.1'),
+        200_000,
+        5_000_000,
+        ethers.utils.parseEther('1.1'),
+        1_000_000,
+      )
+      const gasOracleRunner = await new GasOracleRunner__factory(owner).deploy(gasOracle.address)
+
+      // set eth price
+      ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
+
+      // set compute fee
+      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+
+      // set calldata fee
+      arbGas.getL1BaseFeeEstimate.returns(ethers.utils.parseUnits('10', 9)) // 10 gwei
+
+      // total l2 gas cost = (1_000_000 * 1.1 + 200_000) = 1_300_000
+      // total l2 eth cost = 1_300_000 * 1 gwei = 1.3 * 10^15 = 0.0013 eth
+      // total l1 gas cost = (5_000_000 * 1.2 + 1_000_000) = 7_000_000
+      // total l1 eth cost = 7_000_000 * 10 gwei = 70 * 10^15 = 0.07 eth
+      // total usd cost = 0.0713 * 1000 = 71.3 usd
+      expect(await gasOracleRunner.cost(0))
+        .to.emit(gasOracleRunner, 'Cost')
+        .withArgs(ethers.utils.parseEther('71.3'))
+    })
+
+    it('returns correct cost (value)', async () => {
+      const gasOracle = await new GasOracle__factory(owner).deploy(
+        ethTokenOracleFeed.address,
+        8,
+        1_000_000,
+        ethers.utils.parseEther('1.1'),
+        200_000,
+        0,
+        0,
+        0,
+      )
+      const gasOracleRunner = await new GasOracleRunner__factory(owner).deploy(gasOracle.address)
+
+      // set eth price
+      ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
+
+      // set base fee
+      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+
+      // set value
+      const value = ethers.utils.parseEther('0.0012') // 0.0012 eth
+
+      // total gas cost = (1_000_000 * 1.1 + 200_000) = 1_300_000
+      // total eth cost = 1_300_000 * 1 gwei + 0.0012 eth = 1.3 * 10^15 + 0.0012 eth = 0.0025 eth
+      // total l1 gas cost = (5_000_000 * 1.2 + 1_000_000) = 7_000_000
+      // total l1 eth cost = 7_000_000 * 10 gwei = 70 * 10^15 = 0.07 eth
+      // total usd cost = 0.0725 * 1000 = 72.5 usd
+      expect(await gasOracleRunner.cost(value))
+        .to.emit(gasOracleRunner, 'Cost')
+        .withArgs(ethers.utils.parseEther('72.5'))
+    })
+  })
+})

--- a/test/unit/gas/GasOracle_Arbitrum.test.ts
+++ b/test/unit/gas/GasOracle_Arbitrum.test.ts
@@ -59,7 +59,8 @@ describe('GasOracle_Arbitrum', () => {
       ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
 
       // set compute fee
-      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+      const baseFee = ethers.utils.parseUnits('1', 9)
+      await setBaseFee(baseFee) // 1 gwei
 
       // set calldata fee
       arbGas.getL1BaseFeeEstimate.returns(ethers.utils.parseUnits('10', 9)) // 10 gwei
@@ -69,7 +70,7 @@ describe('GasOracle_Arbitrum', () => {
       // total l1 gas cost = (5_000_000 * 1.2 + 1_000_000) = 7_000_000
       // total l1 eth cost = 7_000_000 * 10 gwei = 70 * 10^15 = 0.07 eth
       // total usd cost = 0.0713 * 1000 = 71.3 usd
-      expect(await gasOracleRunner.cost(0))
+      expect(await gasOracleRunner.cost(0, { gasPrice: baseFee }))
         .to.emit(gasOracleRunner, 'Cost')
         .withArgs(ethers.utils.parseEther('71.3'))
     })
@@ -91,7 +92,8 @@ describe('GasOracle_Arbitrum', () => {
       ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
 
       // set base fee
-      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+      const baseFee = ethers.utils.parseUnits('1', 9)
+      await setBaseFee(baseFee) // 1 gwei
 
       // set value
       const value = ethers.utils.parseEther('0.0012') // 0.0012 eth
@@ -101,7 +103,7 @@ describe('GasOracle_Arbitrum', () => {
       // total l1 gas cost = (5_000_000 * 1.2 + 1_000_000) = 7_000_000
       // total l1 eth cost = 7_000_000 * 10 gwei = 70 * 10^15 = 0.07 eth
       // total usd cost = 0.0725 * 1000 = 72.5 usd
-      expect(await gasOracleRunner.cost(value))
+      expect(await gasOracleRunner.cost(value, { gasPrice: baseFee }))
         .to.emit(gasOracleRunner, 'Cost')
         .withArgs(ethers.utils.parseEther('72.5'))
     })

--- a/test/unit/gas/GasOracle_Optimism.test.ts
+++ b/test/unit/gas/GasOracle_Optimism.test.ts
@@ -1,0 +1,116 @@
+import { smock, FakeContract } from '@defi-wonderland/smock'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import HRE from 'hardhat'
+
+import {
+  AggregatorV3Interface,
+  GasOracle__factory,
+  GasOracleRunner__factory,
+  OptGasInfo,
+} from '../../../types/generated'
+import { BigNumber } from 'ethers'
+
+const { ethers } = HRE
+
+describe('GasOracle_Optimism', () => {
+  let owner: SignerWithAddress
+  let keeper: SignerWithAddress
+  let ethTokenOracleFeed: FakeContract<AggregatorV3Interface>
+  let optGas: FakeContract<OptGasInfo>
+
+  async function setBaseFee(baseFee: BigNumber) {
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', [baseFee.toHexString()])
+    await ethers.provider.send('evm_mine', [])
+  }
+
+  beforeEach(async () => {
+    ;[owner, keeper] = await ethers.getSigners()
+
+    ethTokenOracleFeed = await smock.fake<AggregatorV3Interface>('AggregatorV3Interface')
+
+    optGas = await smock.fake<OptGasInfo>('OptGasInfo', {
+      address: '0x420000000000000000000000000000000000000F',
+    })
+
+    // Set baseFee to 0 to fix sc-coverage issue
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x0'])
+  })
+
+  after(async () => {
+    await ethers.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x1'])
+  })
+
+  describe('#cost', async () => {
+    it('returns correct cost (no value)', async () => {
+      const gasOracle = await new GasOracle__factory(owner).deploy(
+        ethTokenOracleFeed.address,
+        8,
+        1_000_000,
+        ethers.utils.parseEther('1.1'),
+        200_000,
+        5_000_000,
+        ethers.utils.parseEther('1.1'),
+        1_000_000,
+      )
+      const gasOracleRunner = await new GasOracleRunner__factory(owner).deploy(gasOracle.address)
+
+      // set eth price
+      ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
+
+      // set compute fee
+      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+
+      // set calldata fee
+      const L1_BASE_FEE = ethers.utils.parseUnits('5', 'gwei')
+      const L1_BLOB_BASE_FEE = ethers.utils.parseUnits('10', 'gwei')
+      optGas.l1BaseFee.returns(L1_BASE_FEE)
+      optGas.baseFeeScalar.returns(342000)
+      optGas.blobBaseFee.returns(L1_BLOB_BASE_FEE)
+      optGas.blobBaseFeeScalar.returns(684000)
+      optGas.decimals.returns(6)
+
+      // l2 base fee = (16 * 342000 * 5 + 684000 * 10) / (16 * 1_000_000) 2.1375 gwei
+      // total l2 gas cost = (1_000_000 * 1.1 + 200_000) = 1_300_000
+      // total l2 eth cost = 1_300_000 * 2.1375 gwei = 2778750 * 10^15 = 0.00277875 eth
+      // total l1 gas cost = (5_000_000 * 1.2 + 1_000_000) = 7_000_000
+      // total l1 eth cost = 7_000_000 * 10 gwei = 70 * 10^15 = 0.07 eth
+      // total usd cost = 0.07277875 * 1000 = 72.77875 usd
+      expect(await gasOracleRunner.cost(0))
+        .to.emit(gasOracleRunner, 'Cost')
+        .withArgs(ethers.utils.parseEther('72.77875'))
+    })
+
+    it('returns correct cost (value)', async () => {
+      const gasOracle = await new GasOracle__factory(owner).deploy(
+        ethTokenOracleFeed.address,
+        8,
+        1_000_000,
+        ethers.utils.parseEther('1.1'),
+        200_000,
+        0,
+        0,
+        0,
+      )
+      const gasOracleRunner = await new GasOracleRunner__factory(owner).deploy(gasOracle.address)
+
+      // set eth price
+      ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
+
+      // set base fee
+      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+
+      // set value
+      const value = ethers.utils.parseEther('0.0012') // 0.0012 eth
+
+      // total gas cost = (1_000_000 * 1.1 + 200_000) = 1_300_000
+      // total eth cost = 1_300_000 * 2.1375 gwei + 0.0012 eth = 1.3 * 10^15 + 0.0012 eth = 0.00397875 eth
+      // total l1 gas cost = (5_000_000 * 1.2 + 1_000_000) = 7_000_000
+      // total l1 eth cost = 7_000_000 * 10 gwei = 70 * 10^15 = 0.07 eth
+      // total usd cost = 0.07397875 eth * 1000 = 73.97875 usd
+      expect(await gasOracleRunner.cost(value))
+        .to.emit(gasOracleRunner, 'Cost')
+        .withArgs(ethers.utils.parseEther('73.97875'))
+    })
+  })
+})

--- a/test/unit/gas/GasOracle_Optimism.test.ts
+++ b/test/unit/gas/GasOracle_Optimism.test.ts
@@ -59,7 +59,8 @@ describe('GasOracle_Optimism', () => {
       ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
 
       // set compute fee
-      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+      const baseFee = ethers.utils.parseUnits('1', 9)
+      await setBaseFee(baseFee) // 1 gwei
 
       // set calldata fee
       const L1_BASE_FEE = ethers.utils.parseUnits('5', 'gwei')
@@ -76,7 +77,7 @@ describe('GasOracle_Optimism', () => {
       // total l1 gas cost = (5_000_000 * 1.2 + 1_000_000) = 7_000_000
       // total l1 eth cost = 7_000_000 * 10 gwei = 70 * 10^15 = 0.07 eth
       // total usd cost = 0.07277875 * 1000 = 72.77875 usd
-      expect(await gasOracleRunner.cost(0))
+      expect(await gasOracleRunner.cost(0, { gasPrice: baseFee }))
         .to.emit(gasOracleRunner, 'Cost')
         .withArgs(ethers.utils.parseEther('72.77875'))
     })
@@ -98,7 +99,8 @@ describe('GasOracle_Optimism', () => {
       ethTokenOracleFeed.latestRoundData.returns([0, ethers.utils.parseUnits('1000', 8), 0, 0, 0])
 
       // set base fee
-      await setBaseFee(ethers.utils.parseUnits('1', 9)) // 1 gwei
+      const baseFee = ethers.utils.parseUnits('1', 9)
+      await setBaseFee(baseFee) // 1 gwei
 
       // set value
       const value = ethers.utils.parseEther('0.0012') // 0.0012 eth
@@ -108,7 +110,7 @@ describe('GasOracle_Optimism', () => {
       // total l1 gas cost = (5_000_000 * 1.2 + 1_000_000) = 7_000_000
       // total l1 eth cost = 7_000_000 * 10 gwei = 70 * 10^15 = 0.07 eth
       // total usd cost = 0.07397875 eth * 1000 = 73.97875 usd
-      expect(await gasOracleRunner.cost(value))
+      expect(await gasOracleRunner.cost(value, { gasPrice: baseFee }))
         .to.emit(gasOracleRunner, 'Cost')
         .withArgs(ethers.utils.parseEther('73.97875'))
     })


### PR DESCRIPTION
Adds a generic external gas oracle contract.

This works similarly to `Kept` but instead offloads complexity to an external contract for cases where multiple concurrently incentivization flows need to be manage independently.