### PR TITLE
Re-add sc verifier tests

### DIFF
--- a/test/unit/verifier/VerifierBase.ts
+++ b/test/unit/verifier/VerifierBase.ts
@@ -46,6 +46,19 @@ describe('VerifierBase', () => {
       expect(await verifier.nonces(caller.address, 0)).to.eq(true)
     })
 
+    it('should verify default common w/ sc signer', async () => {
+      const common = { ...DEFAULT_COMMON, account: scSigner.address, signer: scSigner.address, domain: caller.address }
+      // signing with caller since sig validation is mocked
+      const signature = await signCommon(caller, verifier, common)
+      scSigner.isValidSignature.returns(0x1626ba7e)
+
+      await expect(verifier.connect(caller).verifyCommon(common, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(scSigner.address, 0)
+
+      expect(await verifier.nonces(scSigner.address, 0)).to.eq(true)
+    })
+
     it('should reject common w/ invalid signer', async () => {
       const common = { ...DEFAULT_COMMON, account: caller.address, signer: market.address, domain: caller.address }
       const signature = await signCommon(caller, verifier, common)
@@ -249,6 +262,27 @@ describe('VerifierBase', () => {
         .withArgs(caller.address, 0)
 
       expect(await verifier.nonces(caller.address, 0)).to.eq(true)
+    })
+
+    it('should verify default group cancellation w/ sc signer', async () => {
+      const groupCancellation = {
+        ...DEFAULT_GROUP_CANCELLATION,
+        common: {
+          ...DEFAULT_GROUP_CANCELLATION.common,
+          account: scSigner.address,
+          signer: scSigner.address,
+          domain: caller.address,
+        },
+      }
+      // signing with caller since sig validation is mocked
+      const signature = await signGroupCancellation(caller, verifier, groupCancellation)
+      scSigner.isValidSignature.returns(0x1626ba7e)
+
+      await expect(verifier.connect(caller).verifyGroupCancellation(groupCancellation, signature))
+        .to.emit(verifier, 'NonceCancelled')
+        .withArgs(scSigner.address, 0)
+
+      expect(await verifier.nonces(scSigner.address, 0)).to.eq(true)
     })
 
     it('should reject group cancellation w/ invalid signer', async () => {


### PR DESCRIPTION
Readded tests which were removed by #104 .  As with the old tests, the signature check is mocked and it's being signed by the caller rather than the sc.