### PR TITLE
Add SynBook6

### DIFF
--- a/contracts/mocks/MockSynBook6.sol
+++ b/contracts/mocks/MockSynBook6.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "../synbook/types/SynBook6.sol";
+
+contract MockSynBook6 {
+    function compute(SynBook6 memory self, Fixed6 latest, Fixed6 change, UFixed6 price) external pure returns (Fixed6) {
+        return SynBook6Lib.compute(self, latest, change, price);
+    }
+}

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/root",
   "description": "Core library for DeFi",
-  "version": "2.3.0-rc8",
+  "version": "2.4.0-rc0",
   "files": [
     "**/*.sol",
     "!/mocks/**/*"

--- a/contracts/synbook/types/SynBook6.sol
+++ b/contracts/synbook/types/SynBook6.sol
@@ -6,10 +6,10 @@ import "../../number/types/UFixed6.sol";
 
 /// @dev SynBook6 type
 struct SynBook6 {
-    Fixed6 d0; // TODO: some of these should be unsigned, ensure p(s) > 0
-    Fixed6 d1;
-    Fixed6 d2;
-    Fixed6 d3;
+    UFixed6 d0;
+    UFixed6 d1;
+    UFixed6 d2;
+    UFixed6 d3;
     UFixed6 scale;
 }
 using SynBook6Lib for SynBook6 global;
@@ -32,48 +32,39 @@ library SynBook6Lib {
         Fixed6 change,
         UFixed6 price
     ) internal pure returns (Fixed6) {
-        (Fixed6 from, Fixed6 to, Fixed6 sign) = (
-            latest.div(Fixed6Lib.from(self.scale)),
-            latest.add(change).div(Fixed6Lib.from(self.scale)),
-            Fixed6Lib.from(change.sign(), UFixed6Lib.ONE)
-        );
+        // sign = 1 for buy / ask and -1 for sell / bid, use f(-x) for sell orders
+        if (change.lt(Fixed6Lib.ZERO)) {
+            latest = latest.mul(Fixed6Lib.NEG_ONE);
+            change = change.mul(Fixed6Lib.NEG_ONE);
+        }
 
-        Fixed6 spread = _indefinite(self.d0, self.d1, self.d2, self.d3, sign, to)
-            .sub(_indefinite(self.d0, self.d1, self.d2, self.d3, sign, from));
+        Fixed6 from = latest.div(Fixed6Lib.from(self.scale));
+        Fixed6 to = latest.add(change).div(Fixed6Lib.from(self.scale));
+        UFixed6 notional = change.abs().mul(price);
 
-        // TODO: put notional in indefinite for increased precision
-        return spread.mul(Fixed6Lib.from(change.abs())).mul(Fixed6Lib.from(price));
+        return _indefinite(self.d0, self.d1, self.d2, self.d3, to, notional)
+            .sub(_indefinite(self.d0, self.d1, self.d2, self.d3, from, notional));
     }
 
     /// @dev f(x) = d0 * x + d1 * x^2 / 2 + d2 * x^3 / 3 + d3 * x^4 / 4
-    /// @dev sign = 1 for buy / ask and -1 for sell / bid
     function _indefinite(
-        Fixed6 d0,
-        Fixed6 d1,
-        Fixed6 d2,
-        Fixed6 d3,
-        Fixed6 sign,
-        Fixed6 value
+        UFixed6 d0,
+        UFixed6 d1,
+        UFixed6 d2,
+        UFixed6 d3,
+        Fixed6 value,
+        UFixed6 notional
     ) private pure returns (Fixed6 result) {
-        Fixed6 x = value;
-        Fixed6 s = sign;
-
         // d0 * x
-        result = s.mul(x).mul(d0);
-        x = x.mul(value);
-        s = s.mul(sign);
+        result = Fixed6Lib.from(notional).mul(value).mul(Fixed6Lib.from(d0));
 
         // d1 * x^2 / 2
-        result = result.add(s.mul(x).mul(d1)).div(Fixed6Lib.from(2));
-        x = x.mul(value);
-        s = s.mul(sign);
+        result = result.add(Fixed6Lib.from(notional).mul(value).mul(value).mul(Fixed6Lib.from(d1)).div(Fixed6Lib.from(2)));
 
         // d2 * x^3 / 3
-        result = result.add(s.mul(x).mul(d2)).div(Fixed6Lib.from(3));
-        x = x.mul(value);
-        s = s.mul(sign);
+        result = result.add(Fixed6Lib.from(notional).mul(value).mul(value).mul(value).mul(Fixed6Lib.from(d2)).div(Fixed6Lib.from(3)));
 
         // d3 * x^4 / 4
-        result = result.add(s.mul(x).mul(d3)).div(Fixed6Lib.from(4));
+        result = result.add(Fixed6Lib.from(notional).mul(value).mul(value).mul(value).mul(value).mul(Fixed6Lib.from(d3)).div(Fixed6Lib.from(4)));
     }
 }

--- a/contracts/synbook/types/SynBook6.sol
+++ b/contracts/synbook/types/SynBook6.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "../../number/types/Fixed6.sol";
+import "../../number/types/UFixed6.sol";
+
+/// @dev SynBook6 type
+struct SynBook6 {
+    Fixed6 d0; // TODO: some of these should be unsigned, ensure p(s) > 0
+    Fixed6 d1;
+    Fixed6 d2;
+    Fixed6 d3;
+    UFixed6 scale;
+}
+using SynBook6Lib for SynBook6 global;
+
+/**
+ * @title SynBook6Lib
+ * @notice Library that that manages the synthetic orderbook mechanism
+ * @dev
+ */
+library SynBook6Lib {
+    /// @notice Computes the spread from the synthetic orderbook
+    /// @param self The synthetic orderbook configuration
+    /// @param latest The latest skew in asset terms
+    /// @param change The change in skew in asset terms
+    /// @param price The price of the underlying asset
+    /// @return The spread in dollar terms
+    function compute(
+        SynBook6 memory self,
+        Fixed6 latest,
+        Fixed6 change,
+        UFixed6 price
+    ) internal pure returns (Fixed6) {
+        (Fixed6 from, Fixed6 to, Fixed6 sign) = (
+            latest.div(Fixed6Lib.from(self.scale)),
+            latest.add(change).div(Fixed6Lib.from(self.scale)),
+            Fixed6Lib.from(change.sign(), UFixed6Lib.ONE)
+        );
+
+        Fixed6 spread = _indefinite(self.d0, self.d1, self.d2, self.d3, sign, to)
+            .sub(_indefinite(self.d0, self.d1, self.d2, self.d3, sign, from));
+
+        // TODO: put notional in indefinite for increased precision
+        return spread.mul(Fixed6Lib.from(change.abs())).mul(Fixed6Lib.from(price));
+    }
+
+    /// @dev f(x) = d0 * x + d1 * x^2 / 2 + d2 * x^3 / 3 + d3 * x^4 / 4
+    /// @dev sign = 1 for buy / ask and -1 for sell / bid
+    function _indefinite(
+        Fixed6 d0,
+        Fixed6 d1,
+        Fixed6 d2,
+        Fixed6 d3,
+        Fixed6 sign,
+        Fixed6 value
+    ) private pure returns (Fixed6 result) {
+        Fixed6 x = value;
+        Fixed6 s = sign;
+
+        // d0 * x
+        result = s.mul(x).mul(d0);
+        x = x.mul(value);
+        s = s.mul(sign);
+
+        // d1 * x^2 / 2
+        result = result.add(s.mul(x).mul(d1)).div(Fixed6Lib.from(2));
+        x = x.mul(value);
+        s = s.mul(sign);
+
+        // d2 * x^3 / 3
+        result = result.add(s.mul(x).mul(d2)).div(Fixed6Lib.from(3));
+        x = x.mul(value);
+        s = s.mul(sign);
+
+        // d3 * x^4 / 4
+        result = result.add(s.mul(x).mul(d3)).div(Fixed6Lib.from(4));
+    }
+}

--- a/contracts/synbook/types/SynBook6.sol
+++ b/contracts/synbook/types/SynBook6.sol
@@ -44,7 +44,7 @@ library SynBook6Lib {
         // TODO: put notional in indefinite for increased precision
         return spread.mul(Fixed6Lib.from(change.abs())).mul(Fixed6Lib.from(price));
     }
-,
+
     /// @dev f(x) = d0 * x + d1 * x^2 / 2 + d2 * x^3 / 3 + d3 * x^4 / 4
     /// @dev sign = 1 for buy / ask and -1 for sell / bid
     function _indefinite(

--- a/contracts/synbook/types/SynBook6.sol
+++ b/contracts/synbook/types/SynBook6.sol
@@ -44,7 +44,7 @@ library SynBook6Lib {
         // TODO: put notional in indefinite for increased precision
         return spread.mul(Fixed6Lib.from(change.abs())).mul(Fixed6Lib.from(price));
     }
-
+,
     /// @dev f(x) = d0 * x + d1 * x^2 / 2 + d2 * x^3 / 3 + d3 * x^4 / 4
     /// @dev sign = 1 for buy / ask and -1 for sell / bid
     function _indefinite(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "2.3.0-rc8",
+  "version": "2.4.0-rc0",
   "scripts": {
     "build": "yarn compile",
     "compile": "hardhat compile",

--- a/test/unit/synbook/SynBook6.test.ts
+++ b/test/unit/synbook/SynBook6.test.ts
@@ -1,0 +1,236 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import HRE from 'hardhat'
+import { MockSynBook6, MockSynBook6__factory } from '../../../types/generated'
+
+const { ethers } = HRE
+
+const CURVE_1 = {
+  d0: ethers.utils.parseUnits('0.002', 6),
+  d1: ethers.utils.parseUnits('0.000', 6),
+  d2: ethers.utils.parseUnits('0.001', 6),
+  d3: ethers.utils.parseUnits('0.010', 6),
+  scale: ethers.utils.parseUnits('1000', 6),
+}
+
+const CURVE_2 = {
+  d0: ethers.utils.parseUnits('0.002', 6),
+  d1: ethers.utils.parseUnits('0.004', 6),
+  d2: ethers.utils.parseUnits('0.001', 6),
+  d3: ethers.utils.parseUnits('0.010', 6),
+  scale: ethers.utils.parseUnits('1000', 6),
+}
+
+describe('SynBook6', () => {
+  let user: SignerWithAddress
+  let synBook: MockSynBook6
+
+  beforeEach(async () => {
+    ;[user] = await ethers.getSigners()
+    synBook = await new MockSynBook6__factory(user).deploy()
+  })
+
+  describe('#compute', async () => {
+    context('CURVE_1', async () => {
+      it('zero skew, zero change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_1,
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('0', 6))
+      })
+
+      it('zero skew, positive change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_1,
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('2.467175', 6))
+      })
+
+      it('zero skew, negative change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_1,
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('-100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('2.467175', 6))
+      })
+
+      it('positive skew, zero change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_1,
+            ethers.utils.parseUnits('200', 6),
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('0', 6))
+      })
+
+      it('positive skew, positive change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_1,
+            ethers.utils.parseUnits('200', 6),
+            ethers.utils.parseUnits('100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('2.737775', 6))
+      })
+
+      it('positive skew, negative change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_1,
+            ethers.utils.parseUnits('200', 6),
+            ethers.utils.parseUnits('-100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('2.442575', 6))
+      })
+
+      it('negative skew, zero change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_1,
+            ethers.utils.parseUnits('-200', 6),
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('0', 6))
+      })
+
+      it('negative skew, positive change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_1,
+            ethers.utils.parseUnits('-200', 6),
+            ethers.utils.parseUnits('100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('2.442575', 6))
+      })
+
+      it('negative skew, negative change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_1,
+            ethers.utils.parseUnits('-200', 6),
+            ethers.utils.parseUnits('-100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('2.737775', 6))
+      })
+    })
+
+    context('CURVE_2', async () => {
+      it('zero skew, zero change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_2,
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('0', 6))
+      })
+
+      it('zero skew, positive change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_2,
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('2.713175', 6))
+      })
+
+      it('zero skew, negative change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_2,
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('-100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('2.713175', 6))
+      })
+
+      it('positive skew, zero change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_2,
+            ethers.utils.parseUnits('200', 6),
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('0', 6))
+      })
+
+      it('positive skew, positive change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_2,
+            ethers.utils.parseUnits('200', 6),
+            ethers.utils.parseUnits('100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('3.967775', 6))
+      })
+
+      it('positive skew, negative change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_2,
+            ethers.utils.parseUnits('200', 6),
+            ethers.utils.parseUnits('-100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('1.704575', 6))
+      })
+
+      it('negative skew, zero change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_2,
+            ethers.utils.parseUnits('-200', 6),
+            ethers.utils.parseUnits('0', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('0', 6))
+      })
+
+      it('negative skew, positive change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_2,
+            ethers.utils.parseUnits('-200', 6),
+            ethers.utils.parseUnits('100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('1.704575', 6))
+      })
+
+      it('negative skew, negative change', async () => {
+        expect(
+          await synBook.compute(
+            CURVE_2,
+            ethers.utils.parseUnits('-200', 6),
+            ethers.utils.parseUnits('-100', 6),
+            ethers.utils.parseUnits('123', 6),
+          ),
+        ).to.equal(ethers.utils.parseUnits('3.967775', 6))
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds unified synthetic orderbook mechanism library.

Allows consumer to compute average spread for orders over a continuous, degree-3 polynomial synthetic representation of an orderbook.

![image](https://github.com/user-attachments/assets/e6cf8c83-e549-4417-a505-d25b7e74c920)
