### PR TITLE
Remove storage helpers from type contracts

### DIFF
--- a/src/accumulator/types/Accumulator6.sol
+++ b/src/accumulator/types/Accumulator6.sol
@@ -10,11 +10,6 @@ struct Accumulator6 {
 }
 
 using Accumulator6Lib for Accumulator6 global;
-struct StoredAccumulator6 {
-    int256 _value;
-}
-struct Accumulator6Storage { StoredAccumulator6 value; }
-using Accumulator6StorageLib for Accumulator6Storage global;
 
 
 /**
@@ -71,16 +66,5 @@ library Accumulator6Lib {
 
     function _mul(Fixed6 amount, UFixed6 total) private pure returns (Fixed6) {
         return amount.sign() == -1 ? amount.mulOut(Fixed6Lib.from(total)) : amount.mul(Fixed6Lib.from(total));
-    }
-}
-
-library Accumulator6StorageLib {
-    function read(Accumulator6Storage storage self) internal view returns (Accumulator6 memory) {
-        StoredAccumulator6 memory storedValue = self.value;
-        return Accumulator6(Fixed6.wrap(int256(storedValue._value)));
-    }
-
-    function store(Accumulator6Storage storage self, Accumulator6 memory newValue) internal {
-        self.value = StoredAccumulator6(Fixed6.unwrap(newValue._value));
     }
 }

--- a/src/accumulator/types/UAccumulator6.sol
+++ b/src/accumulator/types/UAccumulator6.sol
@@ -9,11 +9,6 @@ struct UAccumulator6 {
 }
 
 using UAccumulator6Lib for UAccumulator6 global;
-struct StoredUAccumulator6 {
-    uint256 _value;
-}
-struct UAccumulator6Storage { StoredUAccumulator6 value; }
-using UAccumulator6StorageLib for UAccumulator6Storage global;
 
 
 /**
@@ -49,16 +44,5 @@ library UAccumulator6Lib {
     /// @param self The accumulator to reset
     function reset(UAccumulator6 memory self) internal pure {
         self._value = UFixed6Lib.ZERO;
-    }
-}
-
-library UAccumulator6StorageLib {
-    function read(UAccumulator6Storage storage self) internal view returns (UAccumulator6 memory) {
-        StoredUAccumulator6 memory storedValue = self.value;
-        return UAccumulator6(UFixed6.wrap(uint256(storedValue._value)));
-    }
-
-    function store(UAccumulator6Storage storage self, UAccumulator6 memory newValue) internal {
-        self.value = StoredUAccumulator6(UFixed6.unwrap(newValue._value));
     }
 }

--- a/src/number/types/Fixed18.sol
+++ b/src/number/types/Fixed18.sol
@@ -9,8 +9,6 @@ import "./UFixed18.sol";
 /// @dev Fixed18 type
 type Fixed18 is int256;
 using Fixed18Lib for Fixed18 global;
-type Fixed18Storage is bytes32;
-using Fixed18StorageLib for Fixed18Storage global;
 
 /**
  * @title Fixed18Lib
@@ -381,19 +379,5 @@ library Fixed18Lib {
      */
     function outside(Fixed18 value, Fixed18 min_, Fixed18 max_) internal pure returns (bool) {
         return lt(value, min_) || gt(value, max_);
-    }
-}
-
-library Fixed18StorageLib {
-    function read(Fixed18Storage self) internal view returns (Fixed18 value) {
-        assembly ("memory-safe") {
-            value := sload(self)
-        }
-    }
-
-    function store(Fixed18Storage self, Fixed18 value) internal {
-        assembly ("memory-safe") {
-            sstore(self, value)
-        }
     }
 }

--- a/src/number/types/Fixed6.sol
+++ b/src/number/types/Fixed6.sol
@@ -9,8 +9,6 @@ import "./UFixed6.sol";
 /// @dev Fixed6 type
 type Fixed6 is int256;
 using Fixed6Lib for Fixed6 global;
-type Fixed6Storage is bytes32;
-using Fixed6StorageLib for Fixed6Storage global;
 
 /**
  * @title Fixed6Lib
@@ -391,19 +389,5 @@ library Fixed6Lib {
      */
     function outside(Fixed6 value, Fixed6 min_, Fixed6 max_) internal pure returns (bool) {
         return lt(value, min_) || gt(value, max_);
-    }
-}
-
-library Fixed6StorageLib {
-    function read(Fixed6Storage self) internal view returns (Fixed6 value) {
-        assembly ("memory-safe") {
-            value := sload(self)
-        }
-    }
-
-    function store(Fixed6Storage self, Fixed6 value) internal {
-        assembly ("memory-safe") {
-            sstore(self, value)
-        }
     }
 }

--- a/src/number/types/UFixed18.sol
+++ b/src/number/types/UFixed18.sol
@@ -9,8 +9,6 @@ import "./UFixed6.sol";
 /// @dev UFixed18 type
 type UFixed18 is uint256;
 using UFixed18Lib for UFixed18 global;
-type UFixed18Storage is bytes32;
-using UFixed18StorageLib for UFixed18Storage global;
 
 /**
  * @title UFixed18Lib
@@ -357,19 +355,5 @@ library UFixed18Lib {
      */
     function outside(UFixed18 value, UFixed18 min_, UFixed18 max_) internal pure returns (bool) {
         return lt(value, min_) || gt(value, max_);
-    }
-}
-
-library UFixed18StorageLib {
-    function read(UFixed18Storage self) internal view returns (UFixed18 value) {
-        assembly ("memory-safe") {
-            value := sload(self)
-        }
-    }
-
-    function store(UFixed18Storage self, UFixed18 value) internal {
-        assembly ("memory-safe") {
-            sstore(self, value)
-        }
     }
 }

--- a/src/number/types/UFixed6.sol
+++ b/src/number/types/UFixed6.sol
@@ -9,8 +9,6 @@ import "./UFixed18.sol";
 /// @dev UFixed6 type
 type UFixed6 is uint256;
 using UFixed6Lib for UFixed6 global;
-type UFixed6Storage is bytes32;
-using UFixed6StorageLib for UFixed6Storage global;
 
 /**
  * @title UFixed6Lib
@@ -367,19 +365,5 @@ library UFixed6Lib {
      */
     function outside(UFixed6 value, UFixed6 min_, UFixed6 max_) internal pure returns (bool) {
         return lt(value, min_) || gt(value, max_);
-    }
-}
-
-library UFixed6StorageLib {
-    function read(UFixed6Storage self) internal view returns (UFixed6 value) {
-        assembly ("memory-safe") {
-            value := sload(self)
-        }
-    }
-
-    function store(UFixed6Storage self, UFixed6 value) internal {
-        assembly ("memory-safe") {
-            sstore(self, value)
-        }
     }
 }

--- a/src/token/types/Token18.sol
+++ b/src/token/types/Token18.sol
@@ -9,8 +9,6 @@ import "../../number/types/UFixed18.sol";
 /// @dev Token18
 type Token18 is address;
 using Token18Lib for Token18 global;
-type Token18Storage is bytes32;
-using Token18StorageLib for Token18Storage global;
 
 /**
  * @title Token18Lib
@@ -150,19 +148,5 @@ library Token18Lib {
      */
     function totalSupply(Token18 self) internal view returns (UFixed18) {
         return UFixed18.wrap(IERC20(Token18.unwrap(self)).totalSupply());
-    }
-}
-
-library Token18StorageLib {
-    function read(Token18Storage self) internal view returns (Token18 value) {
-        assembly ("memory-safe") {
-            value := sload(self)
-        }
-    }
-
-    function store(Token18Storage self, Token18 value) internal {
-        assembly ("memory-safe") {
-            sstore(self, value)
-        }
     }
 }

--- a/src/token/types/Token6.sol
+++ b/src/token/types/Token6.sol
@@ -10,8 +10,6 @@ import "../../number/types/UFixed6.sol";
 /// @dev Token6
 type Token6 is address;
 using Token6Lib for Token6 global;
-type Token6Storage is bytes32;
-using Token6StorageLib for Token6Storage global;
 
 /**
  * @title Token6Lib
@@ -152,19 +150,5 @@ library Token6Lib {
      */
     function totalSupply(Token6 self) internal view returns (UFixed6) {
         return UFixed6.wrap(IERC20(Token6.unwrap(self)).totalSupply());
-    }
-}
-
-library Token6StorageLib {
-    function read(Token6Storage self) internal view returns (Token6 value) {
-        assembly ("memory-safe") {
-            value := sload(self)
-        }
-    }
-
-    function store(Token6Storage self, Token6 value) internal {
-        assembly ("memory-safe") {
-            sstore(self, value)
-        }
     }
 }

--- a/test/accumulator/Accumulator6.t.sol
+++ b/test/accumulator/Accumulator6.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import { stdError } from "forge-std/StdError.sol";
 import { RootTest } from "../RootTest.sol";
 
-import { Accumulator6, Accumulator6Storage } from "../../src/accumulator/types/Accumulator6.sol";
+import { Accumulator6 } from "../../src/accumulator/types/Accumulator6.sol";
 import { Fixed6, Fixed6Lib } from "../../src/number/types/Fixed6.sol";
 import { UFixed6, UFixed6Lib } from "../../src/number/types/UFixed6.sol";
 import { NumberMath } from "../../src/number/NumberMath.sol";
@@ -17,7 +17,7 @@ contract Accumulator6Test is RootTest {
     }
 
     function _value() private view returns (Fixed6) {
-        return acc.accumulator()._value;
+        return acc.value();
     }
 
     // increment
@@ -86,19 +86,19 @@ contract Accumulator6Test is RootTest {
     // accumulated
 
     function test_returnsAccumulatedNoRounding() public {
-        Accumulator6 memory from = acc.accumulator();
+        Accumulator6 memory from = acc.getAccumulator();
         acc.increment(Fixed6Lib.from(2), UFixed6Lib.from(5));
         assertFixed6Eq(acc.accumulated(from, UFixed6Lib.from(5)), Fixed6Lib.from(2));
     }
 
     function test_returnsPositiveAccumulatedRoundingDown() public {
-        Accumulator6 memory from = acc.accumulator();
+        Accumulator6 memory from = acc.getAccumulator();
         acc.increment(Fixed6.wrap(1), UFixed6Lib.from(1));
         assertFixed6Eq(acc.accumulated(from, UFixed6.wrap(1)), Fixed6Lib.ZERO);
     }
 
     function test_returnsNegativeAccumulatedRoundingDown() public {
-        Accumulator6 memory from = acc.accumulator();
+        Accumulator6 memory from = acc.getAccumulator();
         acc.decrement(Fixed6.wrap(1), UFixed6Lib.from(1));
         assertFixed6Eq(acc.accumulated(from, UFixed6.wrap(1_000001)), Fixed6.wrap(-2));
     }
@@ -114,31 +114,35 @@ contract Accumulator6Test is RootTest {
 
 contract MockAccumulator6 {
     /// @dev Give tests an accumulator that they can mutate
-    Accumulator6Storage private accumulatorStorage;
+    Accumulator6 private accumulator;
 
-    function accumulator() external view returns (Accumulator6 memory) {
-        return accumulatorStorage.read();
+    function getAccumulator() external view returns (Accumulator6 memory) {
+        return accumulator;
+    }
+
+    function value() external view returns (Fixed6) {
+        return accumulator._value;
     }
 
     function accumulated(Accumulator6 memory from, UFixed6 total) external view returns (Fixed6) {
-        return accumulatorStorage.read().accumulated(from, total);
+        return accumulator.accumulated(from, total);
     }
 
     function increment(Fixed6 amount, UFixed6 total) external {
-        Accumulator6 memory self = accumulatorStorage.read();
+        Accumulator6 memory self = accumulator;
         self.increment(amount, total);
-        accumulatorStorage.store(self);
+        accumulator = self;
     }
 
     function decrement(Fixed6 amount, UFixed6 total) external {
-        Accumulator6 memory self = accumulatorStorage.read();
+        Accumulator6 memory self = accumulator;
         self.decrement(amount, total);
-        accumulatorStorage.store(self);
+        accumulator = self;
     }
 
     function reset() external {
-        Accumulator6 memory self = accumulatorStorage.read();
+        Accumulator6 memory self = accumulator;
         self.reset();
-        accumulatorStorage.store(self);
+        accumulator = self;
     }
 }

--- a/test/accumulator/UAccumulator6.t.sol
+++ b/test/accumulator/UAccumulator6.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import { stdError } from "forge-std/StdError.sol";
 import { RootTest } from "../RootTest.sol";
 
-import { UAccumulator6, UAccumulator6Storage } from "../../src/accumulator/types/UAccumulator6.sol";
+import { UAccumulator6 } from "../../src/accumulator/types/UAccumulator6.sol";
 import { UFixed6, UFixed6Lib } from "../../src/number/types/UFixed6.sol";
 import { NumberMath } from "../../src/number/NumberMath.sol";
 
@@ -16,7 +16,7 @@ contract UAccumulator6Test is RootTest {
     }
 
     function _value() private view returns (UFixed6) {
-        return acc.accumulator()._value;
+        return acc.value();
     }
 
     // increment
@@ -49,13 +49,13 @@ contract UAccumulator6Test is RootTest {
     // accumulated
 
     function test_returnsAccumulatedNoRounding() public {
-        UAccumulator6 memory from = acc.accumulator();
+        UAccumulator6 memory from = acc.getAccumulator();
         acc.increment(UFixed6Lib.from(2), UFixed6Lib.from(5));
         assertUFixed6Eq(acc.accumulated(from, UFixed6Lib.from(5)), UFixed6Lib.from(2));
     }
 
     function test_returnsAccumulatedRoundingDown() public {
-        UAccumulator6 memory from = acc.accumulator();
+        UAccumulator6 memory from = acc.getAccumulator();
         acc.increment(UFixed6.wrap(1), UFixed6Lib.from(1));
         assertUFixed6Eq(acc.accumulated(from, UFixed6Lib.ZERO), UFixed6Lib.ZERO);
     }
@@ -71,25 +71,29 @@ contract UAccumulator6Test is RootTest {
 
 contract MockUAccumulator6 {
     /// @dev Give tests an accumulator that they can mutate
-    UAccumulator6Storage private accumulatorStorage;
+    UAccumulator6 private accumulator;
 
-    function accumulator() external view returns (UAccumulator6 memory) {
-        return accumulatorStorage.read();
+    function getAccumulator() external view returns (UAccumulator6 memory) {
+        return accumulator;
+    }
+
+    function value() external view returns (UFixed6) {
+        return accumulator._value;
     }
 
     function accumulated(UAccumulator6 memory from, UFixed6 total) external view returns (UFixed6) {
-        return accumulatorStorage.read().accumulated(from, total);
+        return accumulator.accumulated(from, total);
     }
 
     function increment(UFixed6 amount, UFixed6 total) external {
-        UAccumulator6 memory self = accumulatorStorage.read();
+        UAccumulator6 memory self = accumulator;
         self.increment(amount, total);
-        accumulatorStorage.store(self);
+        accumulator = self;
     }
 
     function reset() external {
-        UAccumulator6 memory self = accumulatorStorage.read();
+        UAccumulator6 memory self = accumulator;
         self.reset();
-        accumulatorStorage.store(self);
+        accumulator = self;
     }
 }

--- a/test/number/Fixed18.t.sol
+++ b/test/number/Fixed18.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import { stdError } from "forge-std/StdError.sol";
 import { Test } from "forge-std/Test.sol";
 
-import { Fixed18, Fixed18Lib, Fixed18Storage, Fixed18StorageLib } from "../../src/number/types/Fixed18.sol";
+import { Fixed18, Fixed18Lib } from "../../src/number/types/Fixed18.sol";
 import { UFixed18, UFixed18Lib } from "../../src/number/types/UFixed18.sol";
 import { Fixed6, Fixed6Lib } from "../../src/number/types/Fixed6.sol";
 import { NumberMath } from "../../src/number/NumberMath.sol";
@@ -582,12 +582,6 @@ contract Fixed18Test is Test {
         assertEq(Fixed18Lib.outside(a, b, c), true, "below lower bound");
         a = Fixed18.wrap(16);
         assertEq(Fixed18Lib.outside(a, b, c), true, "above upper bound");
-    }
-
-    function test_store() public {
-        Fixed18Storage SLOT = Fixed18Storage.wrap(keccak256("equilibria.root.Fixed18.testSlot"));
-        Fixed18StorageLib.store(SLOT, Fixed18.wrap(-12));
-        assertEq(Fixed18.unwrap(SLOT.read()), -12, "stored and loaded");
     }
 }
 

--- a/test/number/Fixed6.t.sol
+++ b/test/number/Fixed6.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import { stdError } from "forge-std/StdError.sol";
 import { Test } from "forge-std/Test.sol";
 
-import { Fixed6, Fixed6Lib, Fixed6Storage, Fixed6StorageLib } from "../../src/number/types/Fixed6.sol";
+import { Fixed6, Fixed6Lib } from "../../src/number/types/Fixed6.sol";
 import { UFixed6, UFixed6Lib } from "../../src/number/types/UFixed6.sol";
 import { Fixed18, Fixed18Lib } from "../../src/number/types/Fixed18.sol";
 import { NumberMath } from "../../src/number/NumberMath.sol";
@@ -590,12 +590,6 @@ contract Fixed6Test is Test {
         assertEq(Fixed6Lib.outside(a, b, c), true, "below lower bound");
         a = Fixed6.wrap(16);
         assertEq(Fixed6Lib.outside(a, b, c), true, "above upper bound");
-    }
-
-    function test_store() public {
-        Fixed6Storage SLOT = Fixed6Storage.wrap(keccak256("equilibria.root.Fixed6.testSlot"));
-        Fixed6StorageLib.store(SLOT, Fixed6.wrap(-12));
-        assertEq(Fixed6.unwrap(SLOT.read()), -12, "stored and loaded");
     }
 }
 

--- a/test/number/UFixed18.t.sol
+++ b/test/number/UFixed18.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import { stdError } from "forge-std/StdError.sol";
 import { Test } from "forge-std/Test.sol";
 
-import { UFixed18, UFixed18Lib, UFixed18Storage, UFixed18StorageLib } from "../../src/number/types/UFixed18.sol";
+import { UFixed18, UFixed18Lib } from "../../src/number/types/UFixed18.sol";
 import { UFixed6, UFixed6Lib } from "../../src/number/types/UFixed6.sol";
 import { Fixed18, Fixed18Lib } from "../../src/number/types/Fixed18.sol";
 import { NumberMath } from "../../src/number/NumberMath.sol";
@@ -396,12 +396,6 @@ contract UFixed18Test is Test {
         assertEq(UFixed18Lib.outside(a, b, c), true, "below lower bound");
         a = UFixed18.wrap(16);
         assertEq(UFixed18Lib.outside(a, b, c), true, "above upper bound");
-    }
-
-    function test_store() public {
-        UFixed18Storage SLOT = UFixed18Storage.wrap(keccak256("equilibria.root.UFixed18.testSlot"));
-        UFixed18StorageLib.store(SLOT, UFixed18.wrap(12));
-        assertEq(UFixed18.unwrap(SLOT.read()), 12, "stored and loaded");
     }
 }
 

--- a/test/number/UFixed6.t.sol
+++ b/test/number/UFixed6.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import { stdError } from "forge-std/StdError.sol";
 import { Test } from "forge-std/Test.sol";
 
-import { UFixed6, UFixed6Lib, UFixed6Storage, UFixed6StorageLib } from "../../src/number/types/UFixed6.sol";
+import { UFixed6, UFixed6Lib } from "../../src/number/types/UFixed6.sol";
 import { UFixed18, UFixed18Lib } from "../../src/number/types/UFixed18.sol";
 import { Fixed6, Fixed6Lib } from "../../src/number/types/Fixed6.sol";
 import { NumberMath } from "../../src/number/NumberMath.sol";
@@ -407,12 +407,6 @@ contract UFixed6Test is Test {
         assertEq(UFixed6Lib.outside(a, b, c), true, "below lower bound");
         a = UFixed6.wrap(16);
         assertEq(UFixed6Lib.outside(a, b, c), true, "above upper bound");
-    }
-
-    function test_store() public {
-        UFixed6Storage SLOT = UFixed6Storage.wrap(keccak256("equilibria.root.UFixed6.testSlot"));
-        UFixed6StorageLib.store(SLOT, UFixed6.wrap(12));
-        assertEq(UFixed6.unwrap(SLOT.read()), 12, "stored and loaded");
     }
 }
 

--- a/test/token/Token18.t.sol
+++ b/test/token/Token18.t.sol
@@ -6,8 +6,6 @@ import { TokenTest } from "./TokenTest.sol";
 import {
     Token18,
     Token18Lib,
-    Token18Storage,
-    Token18StorageLib,
     UFixed18,
     UFixed18Lib
 } from "../../src/token/types/Token18.sol";
@@ -50,12 +48,6 @@ contract Token18UnfundedUserTest is Token18Test {
     function test_nameAndSymbol() public view{
         assertEq(token.name(), "Test MiNted Token", "name");
         assertEq(token.symbol(), "TMNT", "symbol");
-    }
-
-    function test_store() public {
-        Token18Storage SLOT = Token18Storage.wrap(keccak256("equilibria.root.Token18.testSlot"));
-        Token18StorageLib.store(SLOT, token);
-        assertEq(Token18.unwrap(SLOT.read()), address(erc20), "stored and loaded");
     }
 }
 

--- a/test/token/Token6.t.sol
+++ b/test/token/Token6.t.sol
@@ -6,8 +6,6 @@ import { TokenTest } from "./TokenTest.sol";
 import {
     Token6,
     Token6Lib,
-    Token6Storage,
-    Token6StorageLib,
     UFixed6,
     UFixed6Lib
 } from "../../src/token/types/Token6.sol";
@@ -50,12 +48,6 @@ contract Token6UnfundedUserTest is Token6Test {
     function test_nameAndSymbol() public view {
         assertEq(token.name(), "Test MiNted Token", "name");
         assertEq(token.symbol(), "TMNT", "symbol");
-    }
-
-    function test_store() public {
-        Token6Storage SLOT = Token6Storage.wrap(keccak256("equilibria.root.Token6.testSlot"));
-        Token6StorageLib.store(SLOT, token);
-        assertEq(Token6.unwrap(SLOT.read()), address(erc20), "stored and loaded");
     }
 }
 


### PR DESCRIPTION
Issue: https://linear.app/perennial/issue/PE-2451/[root]-remove-storage-helper-from-type-contracts