### PR TITLE
Misc Updates

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -3,6 +3,7 @@
   "rules": {
     "compiler-version": ["error", "^0.8.13"],
     "contract-name-capwords": "warn",
+    "func-name-mixedcase": "off",
     "func-visibility": ["warn", { "ignoreConstructors": true }],
     "no-inline-assembly": "off",
     "one-contract-per-file": "off",

--- a/src/attribute/Factory.sol
+++ b/src/attribute/Factory.sol
@@ -19,6 +19,7 @@ abstract contract Factory is IFactory, Ownable, Pausable {
     }
 
     /// @dev The erc7201 storage location of the mix-in
+    // solhint-disable-next-line const-name-snakecase
     bytes32 private constant FactoryStorageLocation = 0x2068933510e31bb02be4765cf6d0b2c054190db3eddefe11ffed0ca32b7e6f00;
 
     /// @dev The erc7201 storage of the mix-in

--- a/src/attribute/Factory.sol
+++ b/src/attribute/Factory.sol
@@ -13,8 +13,20 @@ import { Ownable } from "./Ownable.sol";
 /// @notice An abstract factory that manages creates and manages instances
 /// @dev Ownable and Pausable, and satisfies the IBeacon interface by default.
 abstract contract Factory is IFactory, Ownable, Pausable {
-    /// @notice The instances mapping storage slot
-    bytes32 private constant INSTANCE_MAP_SLOT = keccak256("equilibria.root.Factory.instances");
+    /// @custom:storage-location erc7201:equilibria.root.Factory
+    struct FactoryStorage {
+        mapping(IInstance instance => bool registered) instances;
+    }
+
+    /// @dev The erc7201 storage location of the mix-in
+    bytes32 private constant FactoryStorageLocation = 0x2068933510e31bb02be4765cf6d0b2c054190db3eddefe11ffed0ca32b7e6f00;
+
+    /// @dev The erc7201 storage of the mix-in
+    function Factory$() private pure returns (FactoryStorage storage $) {
+        assembly {
+            $.slot := FactoryStorageLocation
+        }
+    }
 
     /// @notice The instance implementation address
     address public immutable implementation;
@@ -32,7 +44,7 @@ abstract contract Factory is IFactory, Ownable, Pausable {
     /// @param instance The instance to check
     /// @return Whether the instance is valid
     function instances(IInstance instance) public view returns (bool) {
-        return _instances()[instance];
+        return Factory$().instances[instance];
     }
 
     /// @notice Creates a new instance
@@ -69,16 +81,8 @@ abstract contract Factory is IFactory, Ownable, Pausable {
     /// @dev Called by _create automatically, or can be called manually in an extending implementation
     /// @param newInstance The new instance
     function _register(IInstance newInstance) internal {
-        _instances()[newInstance] = true;
+        Factory$().instances[newInstance] = true;
         emit InstanceRegistered(newInstance);
-    }
-
-    /// @notice Returns the storage mapping for instances
-    /// @return r The storage mapping for instances
-    function _instances() private pure returns (mapping(IInstance => bool) storage r) {
-        bytes32 slot = INSTANCE_MAP_SLOT;
-        /// @solidity memory-safe-assembly
-        assembly { r.slot := slot }
     }
 
     /// @notice Only allow the function by a valid instance

--- a/src/attribute/Initializable.sol
+++ b/src/attribute/Initializable.sol
@@ -17,6 +17,7 @@ abstract contract Initializable is IInitializable {
     }
 
     /// @dev The erc7201 storage location of the mix-in
+    // solhint-disable-next-line const-name-snakecase
     bytes32 private constant InitializableStorageLocation = 0x08f77ec4fbea51a32ec724cceb179b6666a9be3867a64cbf2c349790a85c2500;
 
     /// @dev The erc7201 storage of the mix-in

--- a/src/attribute/Initializable.sol
+++ b/src/attribute/Initializable.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+import { StorageSlot } from "@openzeppelin/contracts/utils/StorageSlot.sol";
+
 import { IInitializable } from "./interfaces/IInitializable.sol";
 
 /// @title Initializable
@@ -10,29 +12,31 @@ import { IInitializable } from "./interfaces/IInitializable.sol";
 ///      modifier to tag their internal initialization functions to ensure that they can only be called
 ///      from a top-level `initializer` or a constructor.
 abstract contract Initializable is IInitializable {
-    /// @dev The initialized flag
-    uint256 private _version;
+    /// @notice The slot of the initialized version
+    bytes32 private constant VERSION_SLOT = keccak256("equilibria.root.Initializable.version");
 
-    /// @dev The initializing flag
-    bool private _initializing;
+    /// @notice The slot of the initializing flag
+    bytes32 private constant INITIALIZING_SLOT = keccak256("equilibria.root.Initializable.initializing");
 
     /// @dev Can only be called once per version, `version` is 1-indexed
     modifier initializer(uint256 version) {
         if (version == 0) revert InitializableZeroVersionError();
-        if (_version >= version) revert InitializableAlreadyInitializedError(version);
+        if (StorageSlot.getUint256Slot(VERSION_SLOT).value >= version)
+            revert InitializableAlreadyInitializedError(version);
 
-        _version = version;
-        _initializing = true;
+        StorageSlot.getUint256Slot(VERSION_SLOT).value = version;
+        StorageSlot.getBooleanSlot(INITIALIZING_SLOT).value = true;
 
         _;
 
-        _initializing = false;
+        StorageSlot.getBooleanSlot(INITIALIZING_SLOT).value = false;
         emit Initialized(version);
     }
 
     /// @dev Can only be called from an initializer or constructor
     modifier onlyInitializer() {
-        if (!_constructing() && !_initializing) revert InitializableNotInitializingError();
+        if (!_constructing() && !StorageSlot.getBooleanSlot(INITIALIZING_SLOT).value)
+            revert InitializableNotInitializingError();
         _;
     }
 

--- a/src/attribute/Instance.sol
+++ b/src/attribute/Instance.sol
@@ -14,6 +14,7 @@ abstract contract Instance is IInstance, Initializable {
     }
 
     /// @dev The erc7201 storage location of the mix-in
+    // solhint-disable-next-line const-name-snakecase
     bytes32 private constant InstanceStorageLocation = 0xbf37ca0c6353d07d4968ca5873c5b82ea2e21a06e612b4d4a1c55285b8166200;
 
     /// @dev The erc7201 storage of the mix-in

--- a/src/attribute/Instance.sol
+++ b/src/attribute/Instance.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import { StorageSlot } from "@openzeppelin/contracts/utils/StorageSlot.sol";
-
 import { IInstance } from "./interfaces/IInstance.sol";
 import { IFactory } from "./interfaces/IFactory.sol";
 import { Initializable } from "./Initializable.sol";

--- a/src/attribute/Instance.sol
+++ b/src/attribute/Instance.sol
@@ -10,17 +10,29 @@ import { Initializable } from "./Initializable.sol";
 /// @title Instance
 /// @notice An abstract contract that is created and managed by a factory
 abstract contract Instance is IInstance, Initializable {
-    /// @dev The slot of the factory address
-    bytes32 private constant FACTORY_SLOT = keccak256("equilibria.root.Instance.factory");
+    /// @custom:storage-location erc7201:equilibria.root.Instance
+    struct InstanceStorage {
+        IFactory factory;
+    }
+
+    /// @dev The erc7201 storage location of the mix-in
+    bytes32 private constant InstanceStorageLocation = 0xbf37ca0c6353d07d4968ca5873c5b82ea2e21a06e612b4d4a1c55285b8166200;
+
+    /// @dev The erc7201 storage of the mix-in
+    function Instance$() private pure returns (InstanceStorage storage $) {
+        assembly {
+            $.slot := InstanceStorageLocation
+        }
+    }
 
     /// @notice Initializes the contract setting `msg.sender` as the factory
     function __Instance__initialize() internal onlyInitializer {
-        StorageSlot.getAddressSlot(FACTORY_SLOT).value = msg.sender;
+        Instance$().factory = IFactory(msg.sender);
     }
 
     /// @dev The factory that created this instance
     function factory() public view returns (IFactory) {
-        return IFactory(StorageSlot.getAddressSlot(FACTORY_SLOT).value);
+        return Instance$().factory;
     }
 
     /// @notice Only allow the owner defined by the factory to call the function

--- a/src/attribute/Instance.sol
+++ b/src/attribute/Instance.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+import { StorageSlot } from "@openzeppelin/contracts/utils/StorageSlot.sol";
+
 import { IInstance } from "./interfaces/IInstance.sol";
 import { IFactory } from "./interfaces/IFactory.sol";
 import { Initializable } from "./Initializable.sol";
@@ -8,16 +10,17 @@ import { Initializable } from "./Initializable.sol";
 /// @title Instance
 /// @notice An abstract contract that is created and managed by a factory
 abstract contract Instance is IInstance, Initializable {
-    /// @dev The factory address storage slot
-    address private _factory;
-
-    /// @notice Returns the factory that created this instance
-    /// @return The factory that created this instance
-    function factory() public view returns (IFactory) { return IFactory(_factory); }
+    /// @dev The slot of the factory address
+    bytes32 private constant FACTORY_SLOT = keccak256("equilibria.root.Instance.factory");
 
     /// @notice Initializes the contract setting `msg.sender` as the factory
     function __Instance__initialize() internal onlyInitializer {
-        _factory = msg.sender;
+        StorageSlot.getAddressSlot(FACTORY_SLOT).value = msg.sender;
+    }
+
+    /// @dev The factory that created this instance
+    function factory() public view returns (IFactory) {
+        return IFactory(StorageSlot.getAddressSlot(FACTORY_SLOT).value);
     }
 
     /// @notice Only allow the owner defined by the factory to call the function

--- a/src/attribute/Ownable.sol
+++ b/src/attribute/Ownable.sol
@@ -12,20 +12,30 @@ import { IOwnable } from "./interfaces/IOwnable.sol";
 ///      unstructured storage pattern so that it can be safely mixed in with upgradeable
 ///      contracts without affecting their storage patterns through inheritance.
 abstract contract Ownable is IOwnable, Initializable {
-    /// @dev The slot of the owner address
-    bytes32 private constant OWNER_SLOT = keccak256("equilibria.root.Ownable.owner");
+    /// @custom:storage-location erc7201:equilibria.root.Ownable
+    struct OwnableStorage {
+        address owner;
+        address pendingOwner;
+    }
 
-    /// @dev The slot of the pending owner address
-    bytes32 private constant PENDING_OWNER_SLOT = keccak256("equilibria.root.Ownable.pendingOwner");
+    /// @dev The erc7201 storage location of the mix-in
+    bytes32 private constant OwnableStorageLocation = 0x863176706c9b4c9b393005d0714f55de5425abea2a0b5dfac67fac0c9e2ffe00;
+
+    /// @dev The erc7201 storage of the mix-in
+    function Ownable$() private pure returns (OwnableStorage storage $) {
+        assembly {
+            $.slot := OwnableStorageLocation
+        }
+    }
 
     /// @dev The owner address
     function owner() public view returns (address) {
-        return StorageSlot.getAddressSlot(OWNER_SLOT).value;
+        return Ownable$().owner;
     }
 
     /// @dev The pending owner address
     function pendingOwner() public view returns (address) {
-        return StorageSlot.getAddressSlot(PENDING_OWNER_SLOT).value;
+        return Ownable$().pendingOwner;
     }
 
     /// @notice Initializes the contract setting `msg.sender` as the initial owner
@@ -38,7 +48,7 @@ abstract contract Ownable is IOwnable, Initializable {
     /// @dev Can only be called by the current owner
     /// @param newPendingOwner New pending owner address
     function updatePendingOwner(address newPendingOwner) public onlyOwner {
-        StorageSlot.getAddressSlot(PENDING_OWNER_SLOT).value = newPendingOwner;
+        Ownable$().pendingOwner = newPendingOwner;
         emit PendingOwnerUpdated(newPendingOwner);
     }
 
@@ -61,7 +71,7 @@ abstract contract Ownable is IOwnable, Initializable {
     /// @notice Updates the owner address
     /// @param newOwner New owner address
     function _updateOwner(address newOwner) private {
-        StorageSlot.getAddressSlot(OWNER_SLOT).value = newOwner;
+        Ownable$().owner = newOwner;
         emit OwnerUpdated(newOwner);
     }
 

--- a/src/attribute/Ownable.sol
+++ b/src/attribute/Ownable.sol
@@ -17,6 +17,7 @@ abstract contract Ownable is IOwnable, Initializable {
     }
 
     /// @dev The erc7201 storage location of the mix-in
+    // solhint-disable-next-line const-name-snakecase
     bytes32 private constant OwnableStorageLocation = 0x863176706c9b4c9b393005d0714f55de5425abea2a0b5dfac67fac0c9e2ffe00;
 
     /// @dev The erc7201 storage of the mix-in

--- a/src/attribute/Ownable.sol
+++ b/src/attribute/Ownable.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import { StorageSlot } from "@openzeppelin/contracts/utils/StorageSlot.sol";
-
 import { Initializable } from "./Initializable.sol";
 import { IOwnable } from "./interfaces/IOwnable.sol";
 

--- a/src/attribute/Pausable.sol
+++ b/src/attribute/Pausable.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import { Initializable } from "./Initializable.sol";
 import { Ownable } from "./Ownable.sol";
 import { IPausable } from "./interfaces/IPausable.sol";
 
@@ -19,6 +18,7 @@ abstract contract Pausable is IPausable, Ownable {
     }
 
     /// @dev The erc7201 storage location of the mix-in
+    // solhint-disable-next-line const-name-snakecase
     bytes32 private constant PausableStorageLocation = 0x3f6e81f1674f7eaca7e8904fa6f14f10175d4d641e37fc18a3df849e00101900;
 
     /// @dev The erc7201 storage of the mix-in

--- a/src/attribute/Pausable.sol
+++ b/src/attribute/Pausable.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import { StorageSlot } from "@openzeppelin/contracts/utils/StorageSlot.sol";
-
 import { Initializable } from "./Initializable.sol";
 import { Ownable } from "./Ownable.sol";
 import { IPausable } from "./interfaces/IPausable.sol";

--- a/src/attribute/Pausable.sol
+++ b/src/attribute/Pausable.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+import { StorageSlot } from "@openzeppelin/contracts/utils/StorageSlot.sol";
+
 import { Initializable } from "./Initializable.sol";
 import { Ownable } from "./Ownable.sol";
 import { IPausable } from "./interfaces/IPausable.sol";
@@ -12,45 +14,59 @@ import { IPausable } from "./interfaces/IPausable.sol";
 ///      unstructured storage pattern so that it can be safely mixed in with upgradeable
 ///      contracts without affecting their storage patterns through inheritance.
 abstract contract Pausable is IPausable, Ownable {
-    /// @dev The pauser address
-    address private _pauser;
-    function pauser() public view returns (address) { return _pauser; }
+    /// @dev The slot of the pauser address
+    bytes32 private constant PAUSER_SLOT = keccak256("equilibria.root.Pausable.pauser");
 
-    /// @dev Whether the contract is paused
-    bool private _paused;
-    function paused() public view returns (bool) { return _paused; }
+    /// @dev The slot of the paused flag
+    bytes32 private constant PAUSED_SLOT = keccak256("equilibria.root.Pausable.paused");
 
     /// @notice Initializes the contract setting `msg.sender` as the initial pauser
     function __Pausable__initialize() internal onlyInitializer {
         __Ownable__initialize();
-        updatePauser(_sender());
+        updatePauser(msg.sender);
     }
 
     /// @notice Updates the new pauser
     /// @dev Can only be called by the current owner
     /// @param newPauser New pauser address
     function updatePauser(address newPauser) public onlyOwner {
-        _pauser = newPauser;
+        StorageSlot.getAddressSlot(PAUSER_SLOT).value = newPauser;
         emit PauserUpdated(newPauser);
+    }
+
+    /// @dev The pauser address
+    function pauser() public view returns (address) {
+        return StorageSlot.getAddressSlot(PAUSER_SLOT).value;
+    }
+
+    /// @dev Whether the contract is paused
+    function paused() public view returns (bool) {
+        return StorageSlot.getBooleanSlot(PAUSED_SLOT).value;
     }
 
     /// @notice Pauses the contract
     /// @dev Can only be called by the pauser
-    function pause() external onlyPauser {
-        _paused = true;
-        emit Paused();
-    }
+    function pause() external onlyPauser { _pause(); }
 
     /// @notice Unpauses the contract
     /// @dev Can only be called by the pauser
-    function unpause() external onlyPauser {
-        _paused = false;
+    function unpause() external onlyPauser { _unpause(); }
+
+    /// @dev Hook for inheriting contracts to pause the contract
+    function _pause() internal virtual {
+        StorageSlot.getBooleanSlot(PAUSED_SLOT).value = true;
+        emit Paused();
+    }
+
+    /// @dev Hook for inheriting contracts to unpause the contract
+    function _unpause() internal virtual {
+        StorageSlot.getBooleanSlot(PAUSED_SLOT).value = false;
         emit Unpaused();
     }
 
     /// @dev Throws if called by any account other than the pauser
     modifier onlyPauser {
-        if (_sender() != pauser() && _sender() != owner()) revert PausableNotPauserError(_sender());
+        if (msg.sender != pauser() && msg.sender != owner()) revert PausableNotPauserError(msg.sender);
         _;
     }
 


### PR DESCRIPTION
- Update storage pattern of all attributes to use ERC7301.
- Add `_pause()` / `_unpause()` hooks to Pausable for use in inherited contracts.
- Remove `_sender()` hook in `Pausable` and `Ownable` left over from the previous cross-chain support.