### PR TITLE
Improve gas efficiency of sign method

### DIFF
--- a/src/number/types/Fixed18.sol
+++ b/src/number/types/Fixed18.sol
@@ -227,7 +227,7 @@ library Fixed18Lib {
     /// @param a Signed fixed-decimal
     /// @return result Sign of the signed fixed-decimal
     function sign(Fixed18 a) internal pure returns (int256 result) {
-        assembly {
+        assembly ("memory-safe") {
             result := sgt(a, 0)
             result := sub(result, slt(a, 0))
         }

--- a/src/number/types/Fixed18.sol
+++ b/src/number/types/Fixed18.sol
@@ -225,11 +225,12 @@ library Fixed18Lib {
     ///                0 for zero
     ///                1 for positive
     /// @param a Signed fixed-decimal
-    /// @return Sign of the signed fixed-decimal
-    function sign(Fixed18 a) internal pure returns (int256) {
-        if (Fixed18.unwrap(a) > 0) return 1;
-        if (Fixed18.unwrap(a) < 0) return -1;
-        return 0;
+    /// @return result Sign of the signed fixed-decimal
+    function sign(Fixed18 a) internal pure returns (int256 result) {
+        assembly {
+            result := sgt(a, 0)
+            result := sub(result, slt(a, 0))
+        }
     }
 
     /// @notice Returns the absolute value of the signed fixed-decimal

--- a/src/number/types/Fixed6.sol
+++ b/src/number/types/Fixed6.sol
@@ -232,11 +232,12 @@ library Fixed6Lib {
     ///                0 for zero
     ///                1 for positive
     /// @param a Signed fixed-decimal
-    /// @return Sign of the signed fixed-decimal
-    function sign(Fixed6 a) internal pure returns (int256) {
-        if (Fixed6.unwrap(a) > 0) return 1;
-        if (Fixed6.unwrap(a) < 0) return -1;
-        return 0;
+    /// @return result Sign of the signed fixed-decimal
+    function sign(Fixed6 a) internal pure returns (int256 result) {
+        assembly {
+            result := sgt(a, 0)
+            result := sub(result, slt(a, 0))
+        }
     }
 
     /// @notice Returns the absolute value of the signed fixed-decimal

--- a/src/number/types/Fixed6.sol
+++ b/src/number/types/Fixed6.sol
@@ -234,7 +234,7 @@ library Fixed6Lib {
     /// @param a Signed fixed-decimal
     /// @return result Sign of the signed fixed-decimal
     function sign(Fixed6 a) internal pure returns (int256 result) {
-        assembly {
+        assembly ("memory-safe") {
             result := sgt(a, 0)
             result := sub(result, slt(a, 0))
         }


### PR DESCRIPTION
Issue: https://linear.app/perennial/issue/PE-1989/root-improve-performance-of-fixed6sign-and-fixed18sign
- Improved gas efficiency of the `sign` method using assembly. Surprisingly, we don't even need to unwrap when using assembly.

Here are different implementations with their gas costs:
  - Using only assembly
      ```
      function sign(Fixed6 a) internal pure returns (int256 result) {
          assembly {
              result := sgt(a, 0)
              result := sub(result, slt(a, 0))
          }
      }
      ```
      ```
      |----------------------------------------------+-----------------+-----+--------+-----+---------|
      | Function Name                                | Min             | Avg | Median | Max | # Calls |
      |----------------------------------------------+-----------------+-----+--------+-----+---------|
      | sign                                         | 726             | 726  | 726   | 726  | 9      |
      ╰----------------------------------------------+-----------------+-----+--------+-----+---------╯
      ```

  - With unwrap, less than, and greater than check
    ```
    function sign(Fixed6 a) internal pure returns (int256) {
        if (Fixed6.unwrap(a) > 0) return 1;
        if (Fixed6.unwrap(a) < 0) return -1;
        return 0;
    }
    ```
    ```
    |----------------------------------------------+-----------------+-----+--------+-----+---------|
    | Function Name                                | Min             | Avg | Median | Max | # Calls |
    |----------------------------------------------+-----------------+-----+--------+-----+---------|
    | sign                                         | 738             | 750 | 752    | 763 | 9       |
    ╰----------------------------------------------+-----------------+-----+--------+-----+---------╯
    ```

  - Single unwrap, zero check, and leftmost bit check for negative and positive
    ```
    function sign(Fixed6 a) internal pure returns (int256) {
        int256 value = Fixed6.unwrap(a);
        if (value == 0) return 0;
        return (value >> 255 == 0) ? int256(1) : int256(-1);
    }
    ```
    ```
    |----------------------------------------------+-----------------+-----+--------+-----+---------|
    | Function Name                                | Min             | Avg | Median | Max | # Calls |
    |----------------------------------------------+-----------------+-----+--------+-----+---------|
    | sign                                         | 746             | 770 | 769    | 779 | 9       |
    ╰----------------------------------------------+-----------------+-----+--------+-----+---------╯
    ```

  - With unwrap, zero check ,and less than check
    ```
    function sign(Fixed6 a) internal pure returns (int256) {
        if (Fixed6.unwrap(a) == 0) return 0;
        if (Fixed6.unwrap(a) < 0) return -1;
        return 1;
    }
    ```
    ```
    |----------------------------------------------+-----------------+-----+--------+-----+---------|
    | Function Name                                | Min             | Avg | Median | Max | # Calls |
    |----------------------------------------------+-----------------+-----+--------+-----+---------|
    | sign                                         | 734             | 752 | 750    | 760 | 9       |
    ╰----------------------------------------------+-----------------+-----+--------+-----+---------╯
    ```

