### PR TITLE
Add `allowance` method to tokens

### DIFF
--- a/src/distribution/Treasury.sol
+++ b/src/distribution/Treasury.sol
@@ -14,13 +14,13 @@ contract Treasury is ITreasury, Derived, Ownable {
 
     /// @inheritdoc ITreasury
     function credit(Token token, address spender, uint256 creditAmount) external onlyOwner {
-        uint256 currentAllowance = IERC20(Token.unwrap(token)).allowance(address(this), spender);
+        uint256 currentAllowance = token.allowance(spender);
         token.approve(spender, currentAllowance + creditAmount);
     }
 
     /// @inheritdoc ITreasury
     function debit(Token token, address spender, uint256 debitAmount) external onlyOwner {
-        uint256 currentAllowance = IERC20(Token.unwrap(token)).allowance(address(this), spender);
+        uint256 currentAllowance = token.allowance(spender);
         uint256 newAllowance = currentAllowance > debitAmount ? currentAllowance - debitAmount : 0;
         token.approve(spender, newAllowance);
     }

--- a/src/token/types/Token.sol
+++ b/src/token/types/Token.sol
@@ -126,6 +126,23 @@ library TokenLib {
         return IERC20(Token.unwrap(self)).balanceOf(account);
     }
 
+    /// @notice Returns the `self` token allowance of `spender` to spend caller's tokens
+    /// @param self Token to check for
+    /// @param spender Spender to check
+    /// @return Allowance of the spender
+    function allowance(Token self, address spender) internal view returns (uint256) {
+        return IERC20(Token.unwrap(self)).allowance(address(this), spender);
+    }
+
+    /// @notice Returns the `self` token allowance of `spender` to spend `account`'s tokens
+    /// @param self Token to check for
+    /// @param account Account to check
+    /// @param spender Spender to check
+    /// @return Allowance of the spender
+    function allowance(Token self, address account, address spender) internal view returns (uint256) {
+        return IERC20(Token.unwrap(self)).allowance(account, spender);
+    }
+
     /// @notice Returns the `self` total supply
     /// @param self Token to check for
     /// @return The total supply of the token

--- a/src/token/types/Token18.sol
+++ b/src/token/types/Token18.sol
@@ -128,6 +128,23 @@ library Token18Lib {
         return UFixed18.wrap(IERC20(Token18.unwrap(self)).balanceOf(account));
     }
 
+    /// @notice Returns the `self` token allowance of caller to `spender`
+    /// @param self Token to check for
+    /// @param spender Spender to check
+    /// @return Allowance of the caller
+    function allowance(Token18 self, address spender) internal view returns (UFixed18) {
+        return UFixed18.wrap(IERC20(Token18.unwrap(self)).allowance(address(this), spender));
+    }
+
+    /// @notice Returns the `self` token allowance of `account` to `spender`
+    /// @param self Token to check for
+    /// @param account Account to check
+    /// @param spender Spender to check
+    /// @return Allowance of the account
+    function allowance(Token18 self, address account, address spender) internal view returns (UFixed18) {
+        return UFixed18.wrap(IERC20(Token18.unwrap(self)).allowance(account, spender));
+    }
+
     /// @notice Returns the `self` total supply
     /// @param self Token to check for
     /// @return The total supply of the token

--- a/src/token/types/Token6.sol
+++ b/src/token/types/Token6.sol
@@ -129,6 +129,23 @@ library Token6Lib {
         return UFixed6.wrap(IERC20(Token6.unwrap(self)).balanceOf(account));
     }
 
+    /// @notice Returns the `self` token allowance of caller to `spender`
+    /// @param self Token to check for
+    /// @param spender Spender to check
+    /// @return Allowance of the caller
+    function allowance(Token6 self, address spender) internal view returns (UFixed6) {
+        return UFixed6.wrap(IERC20(Token6.unwrap(self)).allowance(address(this), spender));
+    }
+
+    /// @notice Returns the `self` token allowance of `account` to `spender`
+    /// @param self Token to check for
+    /// @param account Account to check
+    /// @param spender Spender to check
+    /// @return Allowance of the account
+    function allowance(Token6 self, address account, address spender) internal view returns (UFixed6) {
+        return UFixed6.wrap(IERC20(Token6.unwrap(self)).allowance(account, spender));
+    }
+
     /// @notice Returns the `self` total supply
     /// @param self Token to check for
     /// @return The total supply of the token

--- a/test/distribution/Treasury.t.sol
+++ b/test/distribution/Treasury.t.sol
@@ -48,7 +48,7 @@ contract TreasuryTest is Test {
         treasury.credit(token, user, amount);
         vm.stopPrank();
 
-        assertEq(MockERC20(Token.unwrap(token)).allowance(address(treasury), user), amount);
+        assertEq(token.allowance(address(treasury), user), amount);
 
         // User pulls tokens from the treasury
         vm.prank(user);
@@ -80,7 +80,7 @@ contract TreasuryTest is Test {
         vm.prank(owner);
         treasury.credit(token, user, 10e18);
 
-        assertEq(MockERC20(Token.unwrap(token)).allowance(address(treasury), user), 110e18);
+        assertEq(token.allowance(address(treasury), user), 110e18);
     }
 
     function test_decreaseAllowance() public {
@@ -92,13 +92,13 @@ contract TreasuryTest is Test {
         vm.prank(owner);
         treasury.debit(token, user, 10e18);
 
-        assertEq(MockERC20(Token.unwrap(token)).allowance(address(treasury), user), 90e18);
+        assertEq(token.allowance(address(treasury), user), 90e18);
 
         // Owner decreases the allowance by more than the current allowance
         vm.prank(owner);
         treasury.debit(token, user, 100e18);
 
         // Ensure the allowance is set to 0
-        assertEq(MockERC20(Token.unwrap(token)).allowance(address(treasury), user), 0);
+        assertEq(token.allowance(address(treasury), user), 0);
     }
 }

--- a/test/token/Token.t.sol
+++ b/test/token/Token.t.sol
@@ -39,6 +39,17 @@ contract TokenUnfundedUserTest is TokenUTest {
         assertEq(erc20.allowance(address(this), user), type(uint256).max, "approve all");
     }
 
+    function test_allowance() public {
+        token.approve(user, 100e18);
+        assertEq(token.allowance(user), 100e18, "allowance of spender to spend caller's tokens");
+    }
+
+    function test_allowanceOf() public {
+        token.approve(user, 100e18);
+        address account = address(this);
+        assertEq(token.allowance(account, user), 100e18, "allowance of spender to spend account's tokens");
+    }
+
     function test_nameAndSymbol() public view {
         assertEq(token.name(), "Test MiNted Token", "name");
         assertEq(token.symbol(), "TMNT", "symbol");

--- a/test/token/Token18.t.sol
+++ b/test/token/Token18.t.sol
@@ -41,6 +41,17 @@ contract Token18UnfundedUserTest is Token18Test {
         assertEq(erc20.allowance(address(this), user), type(uint256).max, "approve all");
     }
 
+    function test_allowance() public {
+        token.approve(user, UFixed18Lib.from(100));
+        assertUFixed18Eq(token.allowance(user), UFixed18Lib.from(100), "allowance of spender to self");
+    }
+
+    function test_allowanceOf() public {
+        token.approve(user, UFixed18Lib.from(100));
+        address account = address(this);
+        assertUFixed18Eq(token.allowance(account, user), UFixed18Lib.from(100), "allowance of spender to account");
+    }
+
     function test_nameAndSymbol() public view{
         assertEq(token.name(), "Test MiNted Token", "name");
         assertEq(token.symbol(), "TMNT", "symbol");

--- a/test/token/Token6.t.sol
+++ b/test/token/Token6.t.sol
@@ -41,6 +41,17 @@ contract Token6UnfundedUserTest is Token6Test {
         assertEq(erc20.allowance(address(this), user), type(uint256).max, "approve all");
     }
 
+    function test_allowance() public {
+        token.approve(user, UFixed6Lib.from(100));
+        assertUFixed6Eq(token.allowance(user), UFixed6Lib.from(100), "allowance of spender to self");
+    }
+
+    function test_allowanceOf() public {
+        token.approve(user, UFixed6Lib.from(100));
+        address account = address(this);
+        assertUFixed6Eq(token.allowance(account, user), UFixed6Lib.from(100), "allowance of spender to account");
+    }
+
     function test_nameAndSymbol() public view {
         assertEq(token.name(), "Test MiNted Token", "name");
         assertEq(token.symbol(), "TMNT", "symbol");


### PR DESCRIPTION
Issue: https://linear.app/perennial/issue/PE-2619/root-add-allowance-to-root-tokens
- Added allowance methods to Tokens to get the spender allowance for the caller and the account.