### PR TITLE
[Fix] Mutable constructor access

### DIFF
--- a/src/mutability/Mutable.sol
+++ b/src/mutability/Mutable.sol
@@ -77,6 +77,9 @@ contract Mutable is IMutableTransparent, Proxy {
 
         // pass through all other calls
         } else {
+            if (msg.sig == IImplementation.construct.selector) {
+                revert MutableDeniedConstructorAccess();
+            }
             super._fallback();
         }
     }
@@ -97,7 +100,7 @@ contract Mutable is IMutableTransparent, Proxy {
         if (newImplementation.version() == Mutable$().version) revert MutableVersionMismatch();
 
         // update the implementation and call its constructor
-        ERC1967Utils.upgradeToAndCall(address(newImplementation),abi.encodeCall(IImplementation.construct, (data)));
+        ERC1967Utils.upgradeToAndCall(address(newImplementation), abi.encodeCall(IImplementation.construct, (data)));
 
         // record the new implementation version
         Mutable$().version = newImplementation.version();

--- a/src/mutability/interfaces/IMutable.sol
+++ b/src/mutability/interfaces/IMutable.sol
@@ -25,6 +25,10 @@ interface IMutableTransparent is IERC1967 {
     /// @dev Mutator functionality was called by a non-mutator.
     error MutableDeniedMutatorAccess();
 
+    // sig: 0x6faec855
+    /// @dev The constructor was called directly.
+    error MutableDeniedConstructorAccess();
+
     // sig: 0x172536eb
     /// @dev The predecessor version of the implementation does not match the previous implementation version.
     error MutablePredecessorMismatch();

--- a/test/mutability/Mutable.t.sol
+++ b/test/mutability/Mutable.t.sol
@@ -81,6 +81,11 @@ contract MutableTestV1 is MutableTestV1Deploy {
         instance1.setValue(106);
     }
 
+    function test_noDirectConstructorAccess() public {
+        vm.expectRevert(IMutableTransparent.MutableDeniedConstructorAccess.selector);
+        instance1.construct("");
+    }
+
     function test_canPause() public {
         vm.prank(owner);
         vm.expectEmit();


### PR DESCRIPTION
Resolves: https://github.com/equilibria-xyz/root/pull/142#discussion_r2090228409.

Since the version check happens in the `Mutable` now instead of the `Implementation`, we don't have a way of checking for re-initialization within the `construct()` method directly. This allows construct to be called repeatedly by anyone.

Instead of sharing state between the `Mutable` and `Implementation`, we can simply block `construct()` from being called through our transparent fallback. Since this method must be defined exactly on each implementation, it's will never be needed to be called directly, rather only through the `Mutator` upgrade flow.