### PR TITLE
Upgrades should not be payable

### DIFF
--- a/src/mutability/Mutator.sol
+++ b/src/mutability/Mutator.sol
@@ -48,7 +48,7 @@ contract Mutator is IMutator, Derived, Pausable {
     function upgrade(IImplementation implementation, bytes memory data) public payable onlyOwner {
         ShortString name = ShortStrings.toShortString(implementation.name());
         if (_nameToMutable[name] == IMutable(address(0))) revert MutatorInvalidMutable();
-        _nameToMutable[name].upgrade{value: msg.value}(implementation, data);
+        _nameToMutable[name].upgrade(implementation, data);
     }
 
     function _pause() internal override {

--- a/src/mutability/interfaces/IMutable.sol
+++ b/src/mutability/interfaces/IMutable.sol
@@ -43,7 +43,7 @@ interface IMutable is IMutableTransparent {
     /// @dev Replaces the implementation, validating name and version
     /// @param newImplementation The new implementation contract
     /// @param data Calldata to invoke the instance's initializer
-    function upgrade(IImplementation newImplementation, bytes calldata data) external payable;
+    function upgrade(IImplementation newImplementation, bytes calldata data) external;
 
     /// @dev Prevents any interaction with the proxied contract.
     /// Implementation may be upgraded when paused.


### PR DESCRIPTION
Any upgrade which transfers ETH will fail because `construct` is nonpayable.  Update interface making upgrades nonpayable, as we have no use for such functionality.