### PR TITLE
Rename `mulDivFixed` to `mulDiv` and `muldivOutFixed` to `muldivOut`

### DIFF
--- a/src/number/types/UFixed6.sol
+++ b/src/number/types/UFixed6.sol
@@ -148,7 +148,7 @@ library UFixed6Lib {
     /// @param c Unsigned number to divide by
     /// @return Resulting computation
     function muldiv(UFixed6 a, uint256 b, uint256 c) internal pure returns (UFixed6) {
-        return muldivFixed(a, UFixed6.wrap(b), UFixed6.wrap(c));
+        return muldiv(a, UFixed6.wrap(b), UFixed6.wrap(c));
     }
 
     /// @notice Computes a * b / c without loss of precision due to BASE conversion, rounding the result up to the next integer if there is a remainder
@@ -157,7 +157,7 @@ library UFixed6Lib {
     /// @param c Unsigned number to divide by
     /// @return Resulting computation
     function muldivOut(UFixed6 a, uint256 b, uint256 c) internal pure returns (UFixed6) {
-        return muldivOutFixed(a, UFixed6.wrap(b), UFixed6.wrap(c));
+        return muldivOut(a, UFixed6.wrap(b), UFixed6.wrap(c));
     }
 
     /// @notice Computes a * b / c without loss of precision due to BASE conversion
@@ -165,7 +165,7 @@ library UFixed6Lib {
     /// @param b Unsigned fixed-decimal to multiply by
     /// @param c Unsigned fixed-decimal to divide by
     /// @return Resulting computation
-    function muldivFixed(UFixed6 a, UFixed6 b, UFixed6 c) internal pure returns (UFixed6) {
+    function muldiv(UFixed6 a, UFixed6 b, UFixed6 c) internal pure returns (UFixed6) {
         return UFixed6.wrap(UFixed6.unwrap(a) * UFixed6.unwrap(b) / UFixed6.unwrap(c));
     }
 
@@ -174,7 +174,7 @@ library UFixed6Lib {
     /// @param b Unsigned fixed-decimal to multiply by
     /// @param c Unsigned fixed-decimal to divide by
     /// @return Resulting computation
-    function muldivOutFixed(UFixed6 a, UFixed6 b, UFixed6 c) internal pure returns (UFixed6) {
+    function muldivOut(UFixed6 a, UFixed6 b, UFixed6 c) internal pure returns (UFixed6) {
         return UFixed6.wrap(NumberMath.divOut(UFixed6.unwrap(a) * UFixed6.unwrap(b), UFixed6.unwrap(c)));
     }
 

--- a/test/number/UFixed6.t.sol
+++ b/test/number/UFixed6.t.sol
@@ -221,11 +221,11 @@ contract UFixed6Test is Test {
 
         UFixed6 b = UFixed6Lib.from(10);
         UFixed6 c = UFixed6Lib.from(2);
-        assertEq(UFixed6.unwrap(a.muldivFixed(b, c)), 100e6, "muldiv(uf6, uf6, uf6)");
+        assertEq(UFixed6.unwrap(a.muldiv(b, c)), 100e6, "muldiv(uf6, uf6, uf6)");
 
         a = UFixed6.wrap(1_111111);
         b = UFixed6.wrap(3_333333);
-        assertEq(UFixed6.unwrap(a.muldivFixed(b, b)), 1_111111, "muldiv(uf6, uf6, uf6) precision");
+        assertEq(UFixed6.unwrap(a.muldiv(b, b)), 1_111111, "muldiv(uf6, uf6, uf6) precision");
     }
 
     function test_mulDivRoundsTowardsZero() public pure {
@@ -235,7 +235,7 @@ contract UFixed6Test is Test {
         a = UFixed6.wrap(1);
         UFixed6 b = UFixed6.wrap(21);
         UFixed6 c = UFixed6.wrap(10);
-        assertEq(UFixed6.unwrap(a.muldivFixed(b, c)), 2, "muldiv(uf6, uf6, uf6) 1*21/10 = 2");
+        assertEq(UFixed6.unwrap(a.muldiv(b, c)), 2, "muldiv(uf6, uf6, uf6) 1*21/10 = 2");
     }
 
     function test_mulDivSignedRevertsIfDivisorIsZero() public {
@@ -258,14 +258,14 @@ contract UFixed6Test is Test {
 
         UFixed6 b = UFixed6Lib.from(10);
         UFixed6 c = UFixed6Lib.from(2);
-        assertEq(UFixed6.unwrap(a.muldivOutFixed(b, c)), 100e6, "muldivOut(uf6, uf6, uf6)");
+        assertEq(UFixed6.unwrap(a.muldivOut(b, c)), 100e6, "muldivOut(uf6, uf6, uf6)");
 
         a = UFixed6.wrap(1_111111);
         uint256 bi = 333333;
         assertEq(UFixed6.unwrap(a.muldivOut(bi, bi)), 1_111111, "muldivOut(uf6, uint256, uint256) precision");
 
         b = UFixed6.wrap(333333);
-        assertEq(UFixed6.unwrap(a.muldivOutFixed(b, b)), 1_111111, "muldivOut(uf6, uf6, uf6) precision");
+        assertEq(UFixed6.unwrap(a.muldivOut(b, b)), 1_111111, "muldivOut(uf6, uf6, uf6) precision");
     }
 
     function test_mulDivOutRoundsAwayFromZero() public pure {
@@ -275,7 +275,7 @@ contract UFixed6Test is Test {
         a = UFixed6.wrap(1);
         UFixed6 b = UFixed6.wrap(21);
         UFixed6 c = UFixed6.wrap(10);
-        assertEq(UFixed6.unwrap(a.muldivOutFixed(b, c)), 3, "muldivOut(uf6, uf6, uf6) 1*21/10 = 3");
+        assertEq(UFixed6.unwrap(a.muldivOut(b, c)), 3, "muldivOut(uf6, uf6, uf6) 1*21/10 = 3");
     }
 
     function test_mulDivOutFixedRevertsIfDivisorIsZero() public {
@@ -470,7 +470,7 @@ contract MockUFixed6 {
     }
 
     function muldivFixed(UFixed6 a, UFixed6 b, UFixed6 c) external pure returns (UFixed6) {
-        return a.muldivFixed(b, c);
+        return a.muldiv(b, c);
     }
 
     function muldivOut(UFixed6 a, uint256 b, uint256 c) external pure returns (UFixed6) {
@@ -478,6 +478,6 @@ contract MockUFixed6 {
     }
 
     function muldivOutFixed(UFixed6 a, UFixed6 b, UFixed6 c) external pure returns (UFixed6) {
-        return a.muldivOutFixed(b, c);
+        return a.muldivOut(b, c);
     }
 }


### PR DESCRIPTION
Issue: https://linear.app/perennial/issue/PE-2914/root-rename-muldivfixed-to-muldiv