### PR TITLE
[Security] Prevent duplicate mutable name collisions in Mutator.create

### DIFF
--- a/src/mutability/Mutator.sol
+++ b/src/mutability/Mutator.sol
@@ -35,8 +35,11 @@ contract Mutator is IMutator, Derived, Pausable {
         IImplementation implementation,
         bytes calldata data
     ) public onlyOwner returns (IMutableTransparent newMutable) {
+        ShortString name = ShortStrings.toShortString(implementation.name());
+        if (_nameToMutable[name] != IMutable(address(0))) revert MutatorMutableAlreadyExists();
+
         _mutables.add(address(newMutable = new Mutable(implementation, data)));
-        _nameToMutable[ShortStrings.toShortString(implementation.name())] = IMutable(address(newMutable));
+        _nameToMutable[name] = IMutable(address(newMutable));
 
         // ensure state of new mutable is consistent with mutator
         if (paused()) IMutable(address(newMutable)).pause();

--- a/src/mutability/interfaces/IMutator.sol
+++ b/src/mutability/interfaces/IMutator.sol
@@ -10,6 +10,7 @@ import { IMutableTransparent } from "./IMutable.sol";
 interface IMutator is IOwnable, IPausable {
     // sig: 0xf125c967
     error MutatorInvalidMutable();
+    error MutatorMutableAlreadyExists();
 
     function mutables() external view returns (address[] memory);
     function create(IImplementation implementation, bytes calldata data) external returns (IMutableTransparent newMutable);

--- a/src/mutability/interfaces/IMutator.sol
+++ b/src/mutability/interfaces/IMutator.sol
@@ -10,6 +10,7 @@ import { IMutableTransparent } from "./IMutable.sol";
 interface IMutator is IOwnable, IPausable {
     // sig: 0xf125c967
     error MutatorInvalidMutable();
+    // sig: 0x77d1c8fc
     error MutatorMutableAlreadyExists();
 
     function mutables() external view returns (address[] memory);

--- a/test/mutability/Mutator.t.sol
+++ b/test/mutability/Mutator.t.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.8.20;
 
 import { IERC1967 } from "@openzeppelin/contracts/interfaces/IERC1967.sol";
 
-import { MutableTestV1Deploy, NewContract, SampleContractV2 } from "./MutabilityTest.sol";
+import { MutableTestV1Deploy, NewContract, SampleContractV1, SampleContractV2 } from "./MutabilityTest.sol";
 import { IOwnable } from "../../src/attribute/Ownable.sol";
 import { IMutableTransparent } from "../../src/mutability/interfaces/IMutable.sol";
+import { IMutator } from "../../src/mutability/interfaces/IMutator.sol";
 import { IPausable } from "../../src/attribute/interfaces/IPausable.sol";
 import { Implementation } from "../../src/mutability/Implementation.sol";
 
@@ -110,6 +111,14 @@ contract MutatorTest is MutableTestV1Deploy {
         assertEq(mutables.length, 2, "Mutables list should contain two mutables");
         assertEq(mutables[0], address(mutableContract), "First mutable should be a SampleContractV1 from setup");
         assertEq(mutables[1], address(newMutable), "Second mutable should be OtherContract from above");
+        vm.stopPrank();
+    }
+
+    function test_revertsOnDuplicateMutableName() public {
+        vm.startPrank(owner);
+        SampleContractV1 duplicateName = new SampleContractV1(999);
+        vm.expectRevert(IMutator.MutatorMutableAlreadyExists.selector);
+        mutator.create(duplicateName, "");
         vm.stopPrank();
     }
 


### PR DESCRIPTION
## Security report

### What was broken
`Mutator.create` allowed deploying multiple mutables with the same `implementation.name()`. The `_nameToMutable` mapping was overwritten, so upgrades would target only the latest mutable and older ones could become upgrade-orphaned.

### What was fixed
- Added `MutatorMutableAlreadyExists()` error to `IMutator`.
- Added a duplicate-name guard in `Mutator.create` before deployment.
- Added regression test `test_revertsOnDuplicateMutableName`.

### Validation
- Ran `forge test --match-path 'test/mutability/Mutator.t.sol' --match-test 'test_revertsOnDuplicateMutableName'`
- Ran `forge test --match-path 'test/mutability/*.sol'`

### Impact
Prevents accidental/procedural bricking of upgrade paths caused by name collisions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to mutable creation semantics plus a new revert case; low blast radius and covered by a targeted test.
> 
> **Overview**
> Prevents deploying multiple mutables with the same `implementation.name()` by adding a pre-deploy guard in `Mutator.create` that reverts when a name is already registered.
> 
> Exposes the new `MutatorMutableAlreadyExists()` error via `IMutator` and adds a regression test (`test_revertsOnDuplicateMutableName`) to ensure duplicate-name creation fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48aff1d5a9f6882b1f0dc66cb76431f1d96a5ddb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->