### PR TITLE
[Security] Restrict OwnableStub.acceptOwner to stub owner

### DIFF
--- a/src/utils/OwnableStub.sol
+++ b/src/utils/OwnableStub.sol
@@ -1,15 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import { Ownable } from "../attribute/Ownable.sol";
+import { Ownable as RootOwnable } from "../attribute/Ownable.sol";
+import { Derived } from "../mutability/Derived.sol";
 
 /// @title OwnableStub
 /// @notice A simple stub contract that can accept ownership but cannot do anything else.
 /// @dev This contract is used to relinquish ownership of a contract by transferring ownership to this stub.
-contract OwnableStub {
+contract OwnableStub is Derived, RootOwnable {
+    constructor() {
+        __Ownable__constructor();
+    }
+
     /// @notice Accepts ownership of the contract
-    /// @dev Can only be called by the pending owner to ensure correctness.
-    function acceptOwner(address ownable) external {
-        Ownable(ownable).acceptOwner();
+    /// @dev Can only be called by the stub owner to avoid permissionless finalization.
+    function acceptOwner(address ownable) external onlyOwner {
+        RootOwnable(ownable).acceptOwner();
     }
 }


### PR DESCRIPTION
## Security report

### What was broken
`OwnableStub.acceptOwner` was permissionless. If a target contract set `OwnableStub` as `pendingOwner`, any external account could trigger acceptance immediately via the stub.

### What was fixed
- Made `OwnableStub` an owned contract (`Derived + Ownable`).
- Added constructor initialization for stub ownership.
- Restricted `acceptOwner` with `onlyOwner`.
- Updated tests to verify:
  - stub owner can accept when stub is pending owner
  - call reverts when stub is not pending owner
  - non-owner cannot finalize acceptance

### Validation
- Ran `forge test --match-path 'test/utils/OwnableStub.t.sol'`
- Ran `forge test --match-path 'test/attribute/Ownable.t.sol'`

### Impact
Removes a permissionless operational hazard and makes ownership relinquish/finalization explicit and owner-controlled.
