### PR TITLE
[Security] Remove unintended payable surface from Mutator.upgrade

### DIFF
--- a/src/mutability/Mutator.sol
+++ b/src/mutability/Mutator.sol
@@ -45,7 +45,7 @@ contract Mutator is IMutator, Derived, Pausable {
     /// @notice Upgrades the implementation of a proxy and optionally calls its initializer
     /// @param implementation New version of contract to be proxied
     /// @param data Calldata to invoke the instance's initializer
-    function upgrade(IImplementation implementation, bytes memory data) public payable onlyOwner {
+    function upgrade(IImplementation implementation, bytes memory data) public onlyOwner {
         ShortString name = ShortStrings.toShortString(implementation.name());
         if (_nameToMutable[name] == IMutable(address(0))) revert MutatorInvalidMutable();
         _nameToMutable[name].upgrade(implementation, data);

--- a/src/mutability/interfaces/IMutator.sol
+++ b/src/mutability/interfaces/IMutator.sol
@@ -13,5 +13,5 @@ interface IMutator is IOwnable, IPausable {
 
     function mutables() external view returns (address[] memory);
     function create(IImplementation implementation, bytes calldata data) external returns (IMutableTransparent newMutable);
-    function upgrade( IImplementation implementation, bytes memory data) external payable;
+    function upgrade( IImplementation implementation, bytes memory data) external;
 }

--- a/test/mutability/Mutator.t.sol
+++ b/test/mutability/Mutator.t.sol
@@ -64,6 +64,15 @@ contract MutatorTest is MutableTestV1Deploy {
         mutator.upgrade(impl2, abi.encode(772));
     }
 
+    function test_revertsUpgradeWithValue() public {
+        SampleContractV2 impl2 = new SampleContractV2(201);
+
+        vm.deal(owner, 1);
+        vm.prank(owner);
+        (bool success,) = address(mutator).call{value: 1}(abi.encodeCall(mutator.upgrade, (impl2, abi.encode(773))));
+        assertFalse(success, "upgrade should reject ETH");
+    }
+
     function test_ownerCanPauseAndUnpause() public {
         vm.startPrank(owner);
         vm.expectEmit();


### PR DESCRIPTION
## Security report

### What was broken
`Mutator.upgrade` was marked `payable` even though it did not forward value and had no ETH recovery path. This left accidental ETH-trap surface.

### Rationale review
Git history shows ETH forwarding on `upgrade` was explicitly removed in commit `84cf9fb` ("updates should not be payable"), indicating payable behavior is not intended in current design. https://github.com/equilibria-xyz/root/pull/155.

### What was fixed
- Removed `payable` from `Mutator.upgrade`.
- Removed `payable` from `IMutator.upgrade`.
- Added regression test `test_revertsUpgradeWithValue` confirming ETH-bearing calls fail.

### Validation
- Ran `forge test --match-path 'test/mutability/Mutator.t.sol' --match-test 'test_revertsUpgradeWithValue'`
- Ran `forge test --match-path 'test/mutability/*.sol'`

### Impact
Eliminates accidental ETH locking risk on upgrade entrypoint while preserving current upgrade semantics.
