### PR TITLE
[Tests] Add 100-mutable pause/unpause gas regression coverage

### DIFF
--- a/test/mutability/Mutator.t.sol
+++ b/test/mutability/Mutator.t.sol
@@ -137,6 +137,7 @@ contract MutatorTest is MutableTestV1Deploy {
     }
 
     function test_pauseUnpauseScalesToHundredMutables() public {
+        // 1 mutable already created in setup, create 99 more
         vm.startPrank(owner);
         for (uint256 i = 0; i < 99; i++) {
             mutator.create(new NewContract(string.concat("N", vm.toString(i))), "");


### PR DESCRIPTION
## Security report

### What was reviewed
Global pause/unpause iterates all mutables by design. This was considered expected behavior, but lacked a scale regression guard.

### What was added
- Added regression test `test_pauseUnpauseScalesToHundredMutables`.
- Test creates 100 mutables and verifies:
  - global pause/unpause executes successfully
  - paused behavior is enforced
  - pause and unpause each stay under a 4,000,000 gas budget

### Validation
- Ran `forge test --match-path 'test/mutability/Mutator.t.sol' --match-test 'test_pauseUnpauseScalesToHundredMutables'`
- Ran `forge test --match-path 'test/mutability/*.sol'`

### Impact
Adds an explicit performance safety rail for operator workflows without changing production logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds a gas/performance guardrail for pause/unpause behavior; no production logic is modified.
> 
> **Overview**
> Adds a new regression test (`test_pauseUnpauseScalesToHundredMutables`) that provisions 100 mutables, then measures `mutator.pause()`/`mutator.unpause()` gas usage and enforces a 4,000,000 gas budget for each.
> 
> The test also asserts that global pause actually blocks calls on a mutable (expects `PausedError`), providing scale/performance coverage without changing production contracts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bd514a08e97ec91667ea9fa4fe537fcd9ec4224. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->