### PR TITLE
[Docs] Align IMutable pause/upgrade behavior

### DIFF
--- a/src/mutability/interfaces/IMutable.sol
+++ b/src/mutability/interfaces/IMutable.sol
@@ -46,7 +46,7 @@ interface IMutable is IMutableTransparent {
     function upgrade(IImplementation newImplementation, bytes calldata data) external;
 
     /// @dev Prevents any interaction with the proxied contract.
-    /// Implementation may be upgraded when paused.
+    /// Implementation upgrades are blocked while paused.
     function pause() external;
 
     /// @dev Allows interaction with the proxied contract


### PR DESCRIPTION
## Security report

### What was broken
`IMutable` documentation stated upgrades may occur while paused, but implementation enforces `whenUnpaused` for upgrade dispatch.

### What was fixed
- Updated interface docs to state upgrades are blocked while paused.

### Validation
- Ran `forge test --match-path 'test/mutability/Mutable.t.sol' --match-test 'test_cantUpgradeWhilePaused'`

### Impact
Removes operator-facing ambiguity and aligns documentation with actual pause controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only contract change plus additional tests; no production logic changes, so behavior risk is minimal.
> 
> **Overview**
> Clarifies `IMutable.pause()` semantics by updating the interface docs to state **implementation upgrades are blocked while paused** (matching current runtime behavior).
> 
> Extends `Mutable.t.sol` with a new test that demonstrates upgrades can still be performed during a pause window only by *atomically* `unpause -> upgrade -> pause`, while confirming standalone `upgrade()` calls revert when paused and that the upgraded implementation/initializer state is applied after unpausing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cbdcf02994196b2925257cc14c985fde34b57e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->