### PR TITLE
Add fallback blocker to Implementation

### DIFF
--- a/src/mutability/Implementation.sol
+++ b/src/mutability/Implementation.sol
@@ -27,6 +27,9 @@ abstract contract Implementation is IImplementation, Contract {
         }
     }
 
+    /// @dev The address of this implementation, used to detect direct (non-proxy) calls.
+    address private immutable __self = address(this);
+
     /// @dev The version of this implementation.
     ShortString private immutable _version;
 
@@ -74,4 +77,14 @@ abstract contract Implementation is IImplementation, Contract {
 
     /// @dev Hook for inheriting contracts to construct the contract.
     function __constructor(bytes memory data) internal virtual returns (string memory);
+
+    /// @dev Blocks direct (non-proxy) calls to the implementation.
+    fallback() external payable {
+        if (address(this) == __self) revert ImplementationDeniedDirectAccess();
+    }
+
+    /// @dev Blocks direct (non-proxy) ETH transfers to the implementation.
+    receive() external payable {
+        if (address(this) == __self) revert ImplementationDeniedDirectAccess();
+    }
 }

--- a/src/mutability/interfaces/IImplementation.sol
+++ b/src/mutability/interfaces/IImplementation.sol
@@ -6,6 +6,10 @@ interface IImplementation {
     /// @dev Thrown when the constructor version of the implementation does not match the version of the implementation.
     error ImplementationConstructorVersionMismatch();
 
+    // sig: 0xadde52c4
+    /// @dev Thrown when the implementation is called directly rather than through a proxy.
+    error ImplementationDeniedDirectAccess();
+
     function name() external view returns (string memory);
     function version() external view returns (string memory);
     function predecessor() external view returns (string memory);

--- a/test/mutability/MutabilityTest.sol
+++ b/test/mutability/MutabilityTest.sol
@@ -57,7 +57,7 @@ abstract contract MutableTestV1Deploy is MutableTest {
         vm.stopPrank();
 
         // initialize the instance
-        instance1 = SampleContractV1(address(mutableContract));
+        instance1 = SampleContractV1(payable(address(mutableContract)));
 
         changeOwner(implementationOwner);
     }
@@ -78,7 +78,7 @@ abstract contract MutableTestV1Deploy is MutableTest {
             impl2,
             abi.encode(uint256(222))
         );
-        return SampleContractV2(address(mutableContract));
+        return SampleContractV2(payable(address(mutableContract)));
     }
 }
 

--- a/test/mutability/Mutable.t.sol
+++ b/test/mutability/Mutable.t.sol
@@ -157,11 +157,41 @@ contract MutableTestV1 is MutableTestV1Deploy {
         vm.prank(owner);
         mutator.unpause();
 
-        SampleContractV2 upgraded = SampleContractV2(address(mutableContract));
+        SampleContractV2 upgraded = SampleContractV2(payable(address(mutableContract)));
         assertEq(upgraded.version(), "2.0.1", "Version should be upgraded after bundle");
         (uint256 value1, int256 value2) = upgraded.getValues();
         assertEq(value1, 113, "value1 should be incremented by V2 initializer");
         assertEq(value2, 333, "value2 should be set by V2 initializer");
+    }
+}
+
+contract MutableTestDirectAccess is MutableTestV1Deploy {
+    function test_directFallbackBlocked() public {
+        // calling the implementation directly with an unknown selector should revert
+        vm.expectRevert(IImplementation.ImplementationDeniedDirectAccess.selector);
+        (bool success,) = address(impl1).call(abi.encodeWithSelector(bytes4(0xdeadbeef)));
+        success; // suppress unused variable warning -- vm.expectRevert absorbs the revert
+    }
+
+    function test_directReceiveBlocked() public {
+        // sending ETH directly to the implementation should revert
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert(IImplementation.ImplementationDeniedDirectAccess.selector);
+        (bool success,) = address(impl1).call{value: 1 ether}("");
+        success;
+    }
+
+    function test_proxyFallbackNotBlocked() public {
+        // calling the proxy with an unknown selector should NOT trigger the direct access error
+        (bool success,) = address(mutableContract).call(abi.encodeWithSelector(bytes4(0xdeadbeef)));
+        assertTrue(success, "Proxy fallback call should succeed");
+    }
+
+    function test_proxyReceiveNotBlocked() public {
+        // sending ETH through the proxy should NOT trigger the direct access error
+        vm.deal(address(this), 1 ether);
+        (bool success,) = address(mutableContract).call{value: 1 ether}("");
+        assertTrue(success, "Proxy receive call should succeed");
     }
 }
 

--- a/test/mutability/Mutator.t.sol
+++ b/test/mutability/Mutator.t.sol
@@ -144,12 +144,12 @@ contract MutatorTest is MutableTestV1Deploy {
 
         // ensure first contract is paused
         address[] memory mutables = mutator.mutables();
-        Implementation contract1 = Implementation(mutables[0]);
+        Implementation contract1 = Implementation(payable(mutables[0]));
         vm.expectRevert(IMutableTransparent.PausedError.selector);
         contract1.name();
 
         // ensure second contract is paused
-        Implementation contract2 = Implementation(mutables[1]);
+        Implementation contract2 = Implementation(payable(mutables[1]));
         vm.expectRevert(IMutableTransparent.PausedError.selector);
         contract2.name();
     }
@@ -171,7 +171,7 @@ contract MutatorTest is MutableTestV1Deploy {
         uint256 pauseGas = gasBeforePause - gasleft();
 
         vm.expectRevert(IMutableTransparent.PausedError.selector);
-        Implementation(mutables[0]).name();
+        Implementation(payable(mutables[0])).name();
 
         vm.prank(owner);
         uint256 gasBeforeUnpause = gasleft();


### PR DESCRIPTION
Adds `fallback()` and `receive()` to `Implementation` that revert when called directly (not via proxy `delegatecall`), preventing ETH from getting stuck in the implementation and blocking undefined-selector calls on the implementation's storage.

Uses the `address(this) == __self` immutable pattern from [OZ's `UUPSUpgradeable._checkProxy()`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.3.0-rc.0/contracts/proxy/utils/UUPSUpgradeable.sol#L21-L102).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core upgradeable `Implementation` behavior by introducing new `fallback`/`receive` revert paths, which could affect integrations that previously (intentionally or accidentally) interacted with implementation addresses. Proxy behavior should be unaffected, but the guard must be correct to avoid breaking delegatecall usage.
> 
> **Overview**
> Prevents *direct* interaction with upgradeable implementation contracts by adding `fallback()` and `receive()` guards to `Implementation` that revert with the new `ImplementationDeniedDirectAccess` error when not executing behind a proxy.
> 
> Updates tests to cover the new direct-access protection (direct unknown-selector calls and ETH transfers now revert, while the proxy path remains allowed) and adjusts several test casts to `payable(address(...))` to satisfy Solidity’s address-payable requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1394122b6116dda55984800411c7f478ac50e86e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implementation contract now blocks direct (non-proxy) access attempts and ETH transfers, preventing unauthorized direct interactions.

* **Tests**
  * Added comprehensive test coverage for direct access control, validating that direct calls and transfers are blocked while proxy-routed operations function normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->