### PR TITLE
Prevent construct() from being called directly on implementation contracts

### DIFF
--- a/src/mutability/Implementation.sol
+++ b/src/mutability/Implementation.sol
@@ -14,6 +14,7 @@ abstract contract Implementation is IImplementation, Contract {
     /// @custom:storage-location erc7201:equilibria.root.Implementation
     struct ImplementationStorage {
         bool constructing;
+        bool constructed;
     }
 
     /// @dev The erc7201 storage location of the mix-in
@@ -37,6 +38,7 @@ abstract contract Implementation is IImplementation, Contract {
     constructor(string memory version_, string memory predecessor_) {
         _version = ShortStrings.toShortString(version_);
         _predecessor = ShortStrings.toShortString(predecessor_);
+        _disableInitializers();
     }
 
     /// @dev The name of the implementation.
@@ -54,6 +56,7 @@ abstract contract Implementation is IImplementation, Contract {
 
     /// @dev Called at upgrade time to initialize the contract with `data`.
     function construct(bytes memory data) external {
+        if (Implementation$().constructed) revert ImplementationAlreadyConstructedError();
         Implementation$().constructing = true;
 
         string memory constructorVersion = __constructor(data);
@@ -70,6 +73,14 @@ abstract contract Implementation is IImplementation, Contract {
     /// @dev The deployer of the contract.
     function _deployer() internal view override returns (address) {
         return IMutator(msg.sender).owner();
+    }
+
+    /// @dev Locks the contract, preventing any future reinitialization. Called in the constructor to
+    ///      prevent the implementation contract from being used directly.
+    /// @custom:oz-ref https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/utils/Initializable.sol#L192C14-L192C34
+    function _disableInitializers() internal virtual {
+        if (Implementation$().constructing) revert ImplementationAlreadyConstructedError();
+        Implementation$().constructed = true;
     }
 
     /// @dev Hook for inheriting contracts to construct the contract.

--- a/src/mutability/interfaces/IImplementation.sol
+++ b/src/mutability/interfaces/IImplementation.sol
@@ -6,6 +6,10 @@ interface IImplementation {
     /// @dev Thrown when the constructor version of the implementation does not match the version of the implementation.
     error ImplementationConstructorVersionMismatch();
 
+    // sig: 0x17e9e41b
+    /// @dev Thrown when construct() is called directly on the implementation contract.
+    error ImplementationAlreadyConstructedError();
+
     function name() external view returns (string memory);
     function version() external view returns (string memory);
     function predecessor() external view returns (string memory);

--- a/test/attribute/Attribute.t.sol
+++ b/test/attribute/Attribute.t.sol
@@ -15,6 +15,8 @@ contract AttributeTest is Test {
         attribute = new MockAttribute();
         mockMutable = new MockMutable(address(this));
 
+        // clear `constructed` flag set by the implementation's constructor for direct unit testing
+        vm.store(address(attribute), 0x3c57b102c533ff058ebe9a7c745178ce4174563553bb3edde7874874c532c200, bytes32(0));
         vm.prank(address(mockMutable));
         attribute.construct(abi.encode("foo"));
     }

--- a/test/attribute/Delegatable.t.sol
+++ b/test/attribute/Delegatable.t.sol
@@ -37,6 +37,8 @@ contract DelegatableTest is Test {
         mockToken.mint(owner, 1000 ether);
         vm.stopPrank();
 
+        // clear `constructed` flag set by the implementation's constructor for direct unit testing
+        vm.store(address(delegatable), 0x3c57b102c533ff058ebe9a7c745178ce4174563553bb3edde7874874c532c200, bytes32(0));
         vm.prank(address(mockMutable));
         delegatable.construct("");
     }

--- a/test/attribute/Executable.t.sol
+++ b/test/attribute/Executable.t.sol
@@ -27,6 +27,8 @@ contract ExecutableTest is Test {
         mockMutable = new MockMutable(owner);
         vm.stopPrank();
 
+        // clear `constructed` flag set by the implementation's constructor for direct unit testing
+        vm.store(address(executable), 0x3c57b102c533ff058ebe9a7c745178ce4174563553bb3edde7874874c532c200, bytes32(0));
         vm.prank(address(mockMutable));
         executable.construct("");
     }

--- a/test/attribute/Ownable.t.sol
+++ b/test/attribute/Ownable.t.sol
@@ -30,6 +30,9 @@ contract OwnableTest is Test {
         vm.prank(owner);
         ownable = new MockOwnable();
         mockMutable = new MockMutable(owner);
+
+        // clear `constructed` flag set by the implementation's constructor for direct unit testing
+        vm.store(address(ownable), 0x3c57b102c533ff058ebe9a7c745178ce4174563553bb3edde7874874c532c200, bytes32(0));
     }
 
     function test_initializeInitializesOwner() public {

--- a/test/attribute/Pausable.t.sol
+++ b/test/attribute/Pausable.t.sol
@@ -31,6 +31,9 @@ contract PausableTest is Test {
         vm.prank(owner);
         pausable = new MockPausable();
         mockMutable = new MockMutable(owner);
+
+        // clear `constructed` flag set by the implementation's constructor for direct unit testing
+        vm.store(address(pausable), 0x3c57b102c533ff058ebe9a7c745178ce4174563553bb3edde7874874c532c200, bytes32(0));
     }
 
     function test_constructor() public {

--- a/test/attribute/Withdrawable.t.sol
+++ b/test/attribute/Withdrawable.t.sol
@@ -33,6 +33,8 @@ contract OwnerWithdrawableTest is Test {
         erc20.mint(owner, 1000);
         vm.stopPrank();
 
+        // clear `constructed` flag set by the implementation's constructor for direct unit testing
+        vm.store(address(withdrawable), 0x3c57b102c533ff058ebe9a7c745178ce4174563553bb3edde7874874c532c200, bytes32(0));
         vm.prank(address(mockMutable));
         withdrawable.construct("");
     }

--- a/test/mutability/Mutable.t.sol
+++ b/test/mutability/Mutable.t.sol
@@ -88,6 +88,11 @@ contract MutableTestV1 is MutableTestV1Deploy {
         instance1.construct("");
     }
 
+    function test_noDirectConstructorAccessOnImplementation() public {
+        vm.expectRevert(IImplementation.ImplementationAlreadyConstructedError.selector);
+        impl1.construct("");
+    }
+
     function test_canPause() public {
         vm.prank(owner);
         vm.expectEmit();

--- a/test/utils/OwnableStub.t.sol
+++ b/test/utils/OwnableStub.t.sol
@@ -27,6 +27,8 @@ contract OwnableStubTest is Test {
         mockMutable = new MockMutable(owner);
         vm.stopPrank();
 
+        // clear `constructed` flag set by the implementation's constructor for direct unit testing
+        vm.store(address(ownableContract), 0x3c57b102c533ff058ebe9a7c745178ce4174563553bb3edde7874874c532c200, bytes32(0));
         vm.prank(address(mockMutable));
         ownableContract.construct("");
     }


### PR DESCRIPTION
Sets a `constructed` flag in the Implementation constructor's ERC-7201 storage slot, causing direct calls to `construct()` on the implementation to revert with `ImplementationAlreadyConstructedError`. Proxy (delegatecall) usage is unaffected since the proxy's own storage is read.

Ref: [OZ `_disableInitializers`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/utils/Initializable.sol#L192C14-L192C34)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core upgrade/initialization plumbing by introducing a new constructed-lock in `Implementation`, so mistakes could brick initialization if the flag is set or cleared incorrectly. Changes are small and covered by updated tests, but the area is security- and lifecycle-sensitive.
> 
> **Overview**
> Prevents calling `construct()` directly on implementation contracts by adding a persistent `constructed` flag in `Implementation`’s ERC-7201 storage, set during the implementation constructor via a new `_disableInitializers()` hook.
> 
> `construct()` now reverts with the new `ImplementationAlreadyConstructedError` when the implementation instance is already locked, while proxy/delegatecall flows continue to rely on the proxy’s own storage. Tests are updated to account for the lock (clearing the storage slot for direct unit tests) and a new regression test asserts direct `construct()` on an implementation reverts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 139a210c490934338a976b68f4e0b48a66f5dd6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implementation contracts now enforce single initialization with automatic safeguards against duplicate construction.

* **Improvements**
  * Introduced new error for detecting and handling duplicate construction attempts on implementation contracts.

* **Tests**
  * Updated test suite infrastructure to accommodate and validate new initialization protection mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->